### PR TITLE
Add concrete PHP/NGINX observability Docker Compose workload and Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,53 @@
 # Intent-to-Auditable-Trust-Object (IATO)
 
-IATO is a deterministic security assurance project focused on producing auditable trust artifacts from reproducible workflows.
+IATO is a deterministic security assurance project designed to transform intent into auditable trust evidence through repeatable controls, telemetry, and policy-driven workflows.
 
-## Repository layout
+## Multi-Step Security Architecture
+
+### Step 1: Define control intent and trust boundaries
+- Identify business-critical systems, data classifications, and trust zones.
+- Map control objectives to:
+  - **Essential Eight** maturity practices (hardening, patching, privilege restriction, MFA, backups).
+  - **SOC 2** trust service criteria (Security, Availability, Processing Integrity, Confidentiality, Privacy).
+- Create system boundaries for applications, supporting services, and third-party integrations.
+
+### Step 2: Establish IAM governance as a first-class control plane
+- Implement role-based access control (RBAC) and least privilege for users, services, and automation identities.
+- Enforce lifecycle controls:
+  - Joiner/Mover/Leaver provisioning and deprovisioning.
+  - Credential rotation and secrets handling.
+  - Break-glass access with approval and immutable audit trail.
+- Require strong authentication (MFA where applicable) and policy-backed authorization.
+
+### Step 3: Build telemetry foundations (logs, metrics, traces)
+- Standardize structured logging at application, infrastructure, and security layers.
+- Expose service and platform metrics for availability, latency, error rate, and saturation.
+- Instrument distributed traces for request-path visibility across dependencies.
+- Protect telemetry integrity with retention, access controls, and tamper-evident storage where required.
+
+### Step 4: Implement monitoring (reactive)
+**Monitoring answers: _"What is failing?"_**
+- Define predefined, threshold-based metrics and SLO/SLI alerts (for example CPU, memory, 5xx rate, queue lag, cert expiry).
+- Route alerts to on-call workflows with severity, ownership, and escalation policy.
+- Use runbooks for deterministic triage and incident response.
+
+### Step 5: Implement observability (proactive + investigative)
+**Observability answers: _"Why is it failing?"_**
+- Correlate logs, metrics, and traces to identify causal paths and hidden system interactions.
+- Support exploratory investigation beyond predefined dashboards.
+- Use high-cardinality dimensions and trace context to isolate blast radius and root cause quickly.
+
+### Step 6: Close the assurance loop with evidence and audits
+- Continuously map telemetry and control outputs to Essential Eight and SOC 2 control evidence.
+- Capture:
+  - Control execution logs.
+  - IAM decision records.
+  - Incident timelines and corrective actions.
+- Produce auditable trust artifacts from reproducible pipelines.
+
+---
+
+## Repository Layout
 
 - `config/` — environment defaults, runtime/security settings, and setup helpers.
 - `scripts/` — core research and orchestration scripts.
@@ -10,17 +55,144 @@ IATO is a deterministic security assurance project focused on producing auditabl
 - `docs/` — project documentation and notes.
 - `docker/` — local container and observability stack assets.
 - `ci/` — CI checks and environment validation scripts.
-- `bin/` — archived/legacy helper files that are not part of the primary workflow.
+- `bin/` — archived/legacy helper files not used in the primary workflow.
 
-## Getting started
+## Docker Images and Dev Environment Dependencies
 
-1. Create the environment:
+The repository includes container assets for local execution and observability testing. For a PHP-based web control plane that supports both Apache and NGINX reverse proxy patterns, use the following baseline dependencies.
+
+### PHP + Apache base image (application runtime)
+
+```dockerfile
+FROM php:8.2-apache
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    git \
+    unzip \
+    libzip-dev \
+    libicu-dev \
+    libonig-dev \
+    libxml2-dev \
+    && docker-php-ext-install pdo pdo_mysql intl zip \
+    && a2enmod rewrite headers ssl status \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /var/www/html
+COPY . /var/www/html
+```
+
+### NGINX sidecar/reverse proxy dependency
+- `nginx:alpine` for request routing and static content acceleration in local development.
+- Bind-mounted configuration from `docker/nginx/php-observability.nginx.conf` for PHP upstream routing.
+- Route upstream traffic to the PHP/Apache service.
+
+### Real workload compose example (`docker/compose/php-observability-stack.yml`)
+
+```yaml
+version: "3.9"
+
+networks:
+  iato-net:
+    driver: bridge
+
+volumes:
+  redis-data:
+  prometheus-data:
+  grafana-data:
+
+services:
+  php-apache:
+    build:
+      context: ../..
+      dockerfile: docker/php-apache.Dockerfile
+    container_name: iato-php-apache
+    environment:
+      APP_ENV: dev
+      APP_DEBUG: "true"
+      REDIS_HOST: redis
+    volumes:
+      - ../../:/var/www/html
+      - ../../docker/src/99-local.ini:/usr/local/etc/php/conf.d/99-local.ini:ro
+      - ../../docker/src/status.conf:/etc/apache2/conf-enabled/status.conf:ro
+    expose:
+      - "80"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/server-status?auto"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    networks:
+      - iato-net
+
+  nginx:
+    image: nginx:alpine
+    container_name: iato-nginx
+    depends_on:
+      php-apache:
+        condition: service_healthy
+    ports:
+      - "8080:80"
+    volumes:
+      - ../../docker/nginx/php-observability.nginx.conf:/etc/nginx/nginx.conf:ro
+      - ../../docker/nginx/ssl:/etc/nginx/ssl:ro
+    networks:
+      - iato-net
+
+  redis:
+    image: redis:7-alpine
+    container_name: iato-redis
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis-data:/data
+    networks:
+      - iato-net
+
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    container_name: iato-prometheus
+    command: ["--config.file=/etc/prometheus/prometheus.yml", "--storage.tsdb.path=/prometheus"]
+    ports:
+      - "9090:9090"
+    volumes:
+      - ../../docker/rules/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    networks:
+      - iato-net
+
+  grafana:
+    image: grafana/grafana:11.1.4
+    container_name: iato-grafana
+    depends_on:
+      - prometheus
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+    volumes:
+      - grafana-data:/var/lib/grafana
+    networks:
+      - iato-net
+```
+
+Run it with:
+
+```bash
+docker compose -f docker/compose/php-observability-stack.yml up --build
+```
+
+## Getting Started
+
+1. Create the Python environment:
    - `conda env create -f environment.yml`
 2. Activate it:
    - `conda activate testenv`
 3. Run repository checks:
    - `bash ci/tools/run_all_checks.sh`
+4. (Optional) Start container stack:
+   - `docker compose -f docker/compose/docker-compose.yml up --build`
 
-## Scope note
+## Scope Note
 
-This repository contains both active code and historical artifacts. Prefer content under `config/`, `scripts/`, `tests/`, `docs/`, `docker/`, and `ci/tools/` for current workflows.
+This repository includes both active workflows and historical artifacts. Prioritize `config/`, `scripts/`, `tests/`, `docs/`, `docker/`, and `ci/tools/` for current implementation paths.

--- a/docker/compose/php-observability-stack.yml
+++ b/docker/compose/php-observability-stack.yml
@@ -1,0 +1,84 @@
+version: "3.9"
+
+networks:
+  iato-net:
+    driver: bridge
+
+volumes:
+  redis-data:
+  prometheus-data:
+  grafana-data:
+
+services:
+  php-apache:
+    build:
+      context: ../..
+      dockerfile: docker/php-apache.Dockerfile
+    container_name: iato-php-apache
+    environment:
+      APP_ENV: dev
+      APP_DEBUG: "true"
+      REDIS_HOST: redis
+    volumes:
+      - ../../:/var/www/html
+      - ../../docker/src/99-local.ini:/usr/local/etc/php/conf.d/99-local.ini:ro
+      - ../../docker/src/status.conf:/etc/apache2/conf-enabled/status.conf:ro
+    expose:
+      - "80"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/server-status?auto"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    networks:
+      - iato-net
+
+  nginx:
+    image: nginx:alpine
+    container_name: iato-nginx
+    depends_on:
+      php-apache:
+        condition: service_healthy
+    ports:
+      - "8080:80"
+    volumes:
+      - ../../docker/nginx/php-observability.nginx.conf:/etc/nginx/nginx.conf:ro
+      - ../../docker/nginx/ssl:/etc/nginx/ssl:ro
+    networks:
+      - iato-net
+
+  redis:
+    image: redis:7-alpine
+    container_name: iato-redis
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis-data:/data
+    networks:
+      - iato-net
+
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    container_name: iato-prometheus
+    command: ["--config.file=/etc/prometheus/prometheus.yml", "--storage.tsdb.path=/prometheus"]
+    ports:
+      - "9090:9090"
+    volumes:
+      - ../../docker/rules/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    networks:
+      - iato-net
+
+  grafana:
+    image: grafana/grafana:11.1.4
+    container_name: iato-grafana
+    depends_on:
+      - prometheus
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+    volumes:
+      - grafana-data:/var/lib/grafana
+    networks:
+      - iato-net

--- a/docker/nginx/php-observability.nginx.conf
+++ b/docker/nginx/php-observability.nginx.conf
@@ -1,0 +1,16 @@
+events { }
+
+http {
+    server {
+        listen 80;
+        server_name localhost;
+
+        location / {
+            proxy_pass http://php-apache:80;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}

--- a/docker/php-apache.Dockerfile
+++ b/docker/php-apache.Dockerfile
@@ -1,0 +1,16 @@
+FROM php:8.2-apache
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    git \
+    unzip \
+    libzip-dev \
+    libicu-dev \
+    libonig-dev \
+    libxml2-dev \
+    && docker-php-ext-install pdo pdo_mysql intl zip \
+    && a2enmod rewrite headers ssl status \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /var/www/html
+COPY . /var/www/html


### PR DESCRIPTION
### Motivation
- Replace the prior pseudocode/local-snippet with a runnable, real-world compose workload so developers can spin up a PHP control-plane and observability stack for local testing.
- Provide an explicit build artifact for the PHP runtime so the compose example references an actual `Dockerfile` rather than only documentation.
- Make it easier to test HTTP routing and service health by adding an NGINX upstream config and a `healthcheck` for the PHP service.

### Description
- Replaced the lightweight compose snippet in `README.md` with a concrete example referencing `docker/compose/php-observability-stack.yml` and updated guidance and run command in the README.
- Added `docker/compose/php-observability-stack.yml` containing services: `php-apache`, `nginx`, `redis`, `prometheus`, and `grafana`, with named volumes, a shared network, and a `healthcheck` for `php-apache`.
- Added `docker/php-apache.Dockerfile` as the PHP/Apache base image used by the compose file and `docker/nginx/php-observability.nginx.conf` to proxy requests to the `php-apache` upstream.
- Updated the README NGINX notes to reference the new NGINX config file and clarified the local dev use-case.

### Testing
- Ran `bash ci/tools/run_all_checks.sh`, which executed system checks but failed due to a missing dependency: `ERROR: pandoc not found in PATH` (failed).
- Attempted `docker compose -f docker/compose/php-observability-stack.yml config`, which could not run in this environment because the `docker` CLI is not available (failed).
- Attempted a YAML parse using Python (`PyYAML`) against `docker/compose/php-observability-stack.yml`, which failed because the `yaml` module is not installed in this environment (`ModuleNotFoundError`) (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699228819ec083238fc756da1b2049ec)