### PR TITLE
Add evidence record schema validation tests

### DIFF
--- a/tests/tools/test_evidence_record_schema.py
+++ b/tests/tools/test_evidence_record_schema.py
@@ -1,0 +1,87 @@
+"""Validation tests for the minimal IATO evidence record schema."""
+
+from datetime import datetime
+
+REQUIRED_FIELDS = {
+    "control_id",
+    "service",
+    "environment",
+    "timestamp_utc",
+    "source",
+    "artifact_uri",
+    "hash_sha256",
+    "mapped_controls",
+}
+
+
+def validate_evidence_record(record: dict) -> None:
+    missing = REQUIRED_FIELDS - set(record)
+    assert not missing, f"missing required fields: {sorted(missing)}"
+
+    timestamp = record["timestamp_utc"]
+    assert isinstance(timestamp, str) and timestamp.endswith("Z"), "timestamp_utc must be an ISO8601 UTC string"
+    # Convert `Z` to explicit UTC offset for parsing.
+    datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+
+    mapped_controls = record["mapped_controls"]
+    assert isinstance(mapped_controls, str) and mapped_controls.strip(), "mapped_controls must be a non-empty string"
+    prefixes = ("SOC2:", "ASVS:", "E8:")
+    assert any(prefix in mapped_controls for prefix in prefixes), (
+        "mapped_controls should include at least one SOC2/ASVS/E8 reference"
+    )
+
+    if "exception_id" in record:
+        assert "approver" in record and record["approver"], "approver is required when exception_id is set"
+
+
+def test_accepts_baseline_evidence_record():
+    record = {
+        "control_id": "CTRL-IAM-006",
+        "service": "payments-api",
+        "environment": "prod",
+        "timestamp_utc": "2026-02-15T02:30:00Z",
+        "source": "ci/tools/run_all_checks.sh",
+        "artifact_uri": "s3://audit-bucket/evidence/packet.json",
+        "hash_sha256": "a" * 64,
+        "mapped_controls": "SOC2:CC6.1, ASVS:V2, E8:MFA",
+    }
+
+    validate_evidence_record(record)
+
+
+def test_accepts_exception_record_with_approver():
+    record = {
+        "control_id": "CTRL-IAM-006",
+        "service": "payments-api",
+        "environment": "prod",
+        "timestamp_utc": "2026-02-15T02:30:00Z",
+        "source": "ci/tools/run_all_checks.sh",
+        "artifact_uri": "s3://audit-bucket/evidence/packet.json",
+        "hash_sha256": "a" * 64,
+        "mapped_controls": "SOC2:CC6.1, ASVS:V2, E8:MFA",
+        "exception_id": "EXC-2026-0042",
+        "approver": "security-oncall",
+    }
+
+    validate_evidence_record(record)
+
+
+def test_rejects_exception_without_approver():
+    record = {
+        "control_id": "CTRL-IAM-006",
+        "service": "payments-api",
+        "environment": "prod",
+        "timestamp_utc": "2026-02-15T02:30:00Z",
+        "source": "ci/tools/run_all_checks.sh",
+        "artifact_uri": "s3://audit-bucket/evidence/packet.json",
+        "hash_sha256": "a" * 64,
+        "mapped_controls": "SOC2:CC6.1, ASVS:V2, E8:MFA",
+        "exception_id": "EXC-2026-0042",
+    }
+
+    try:
+        validate_evidence_record(record)
+    except AssertionError as exc:
+        assert "approver is required" in str(exc)
+    else:
+        raise AssertionError("Expected validation failure when exception_id is set without approver")


### PR DESCRIPTION
### Motivation
- Provide automated validation for the repository's minimal IATO evidence record schema as documented in `README.md`. 
- Catch regressions around required fields and conditional exception handling (an exception must include an approver).

### Description
- Add `tests/tools/test_evidence_record_schema.py` which implements `validate_evidence_record` and enforces required fields, `timestamp_utc` ISO8601-UTC format (trailing `Z`), presence of mapped control references (`SOC2:`, `ASVS:`, or `E8:`), and the rule that `exception_id` requires `approver`.
- Add three tests covering a baseline valid record, a valid exception record with an approver, and a negative test that asserts failure when `exception_id` is present without `approver`.

### Testing
- Ran `pytest -q tests/tools/test_evidence_record_schema.py` and received `3 passed`.
- Ran `pytest -q tests/tools/test_imports.py tests/tools/test_env_checks.py` and observed a failure due to the test environment missing the `numpy` package (environment issue).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699242cc74408328acf1a79c6933ef34)