### PR TITLE
docs: pin root container/project config files in README layout section

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,14 @@ High-signal directories only:
 - `bin/docs/` — archival notes and process documentation.
 - `bin/web-assets/` — static dependency visualization assets.
 
+Pinned root configuration files:
+
+- `.dockerignore` — controls Docker build context size and excludes local cache/artifact files.
+- `.env.example` — baseline environment variables for local Docker stack startup.
+- `Dockerfile` — base PHP-FPM image definition used for repository containerization workflows.
+- `docker-compose.yml` — canonical local multi-service stack (`nginx`, `apache`, `drupal`, `db`).
+- `pyproject.toml` — Python project metadata and conda-lock dependency configuration.
+
 ---
 
 ## 7) Deployment and Local Validation .....


### PR DESCRIPTION
### Motivation

- Make the repo README explicitly surface key top-level configuration files so local developers and automation can quickly find and pin the canonical container and Python project artifacts.

### Description

- Add a new "Pinned root configuration files" subsection under the `Repository Layout` section in `README.md` listing and describing `.dockerignore`, `.env.example`, `Dockerfile`, `docker-compose.yml`, and `pyproject.toml`.

### Testing

- Verified the README update is present in the expected section by inspecting `README.md`, which succeeded.  
- Ran `git status --short` and `git show --stat --oneline HEAD` to confirm the working tree and recent changes are visible, both commands returned successfully.  
- Attempted `docker compose config` to render the compose file but it failed due to the Docker CLI not being available in this environment.  
- Attempted to parse `pyproject.toml` with a small Python `tomllib` check which failed because `tomllib` is not present in the runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992666681d88328ace8f9e60b828ab1)