### PR TITLE
Add C# PCAP TCP handshake CSV exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,3 +305,32 @@ The repository cyber risk management controls document is available at:
 - [`docs/cyber-risk-controls.md`](docs/cyber-risk-controls.md)
 
 Also see [Control Mapping](#4-control-mapping-soc-2--asvs--essential-eight) and [Evidence Model](#5-evidence-model-maintainable-by-default) for implementation context.
+
+---
+
+## 11) PCAP TCP Handshake Exporter (C#)
+
+A small .NET console app is provided at `src/PcapHandshakeExporter` to parse `.pcap` files with **SharpPcap** and **PacketDotNet**, then export TCP handshake packets (`SYN`, `SYN-ACK`, `ACK`) to `handshake_data.csv`.
+
+### Build
+
+```bash
+dotnet build src/PcapHandshakeExporter/PcapHandshakeExporter.csproj
+```
+
+### Run
+
+```bash
+dotnet run --project src/PcapHandshakeExporter/PcapHandshakeExporter.csproj -- /path/to/capture.pcap
+```
+
+### CSV Output
+
+`handshake_data.csv` contains:
+
+- `Timestamp`
+- `SourceIP`
+- `DestinationIP`
+- `SequenceNumber`
+- `AcknowledgmentNumber`
+- `HandshakeType`

--- a/src/PcapHandshakeExporter/PcapHandshakeExporter.csproj
+++ b/src/PcapHandshakeExporter/PcapHandshakeExporter.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="PacketDotNet" Version="1.4.7" />
+    <PackageReference Include="SharpPcap" Version="6.3.0" />
+  </ItemGroup>
+</Project>

--- a/src/PcapHandshakeExporter/Program.cs
+++ b/src/PcapHandshakeExporter/Program.cs
@@ -1,0 +1,87 @@
+using System.Globalization;
+using PacketDotNet;
+using SharpPcap;
+
+if (args.Length == 0)
+{
+    Console.WriteLine("Usage: dotnet run -- <path-to-pcap-file>");
+    return;
+}
+
+var pcapFilePath = args[0];
+if (!File.Exists(pcapFilePath))
+{
+    Console.Error.WriteLine($"PCAP file not found: {pcapFilePath}");
+    return;
+}
+
+const string outputFileName = "handshake_data.csv";
+
+using var writer = new StreamWriter(outputFileName, false);
+writer.WriteLine("Timestamp,SourceIP,DestinationIP,SequenceNumber,AcknowledgmentNumber,HandshakeType");
+
+using var device = new CaptureFileReaderDevice(pcapFilePath);
+device.Open();
+
+RawCapture? rawCapture;
+while ((rawCapture = device.GetNextPacket()) != null)
+{
+    var packet = Packet.ParsePacket(rawCapture.LinkLayerType, rawCapture.Data);
+    var ipPacket = packet.Extract<IPPacket>();
+    var tcpPacket = packet.Extract<TcpPacket>();
+
+    if (ipPacket is null || tcpPacket is null)
+    {
+        continue;
+    }
+
+    var handshakeType = GetHandshakeType(tcpPacket);
+    if (handshakeType is null)
+    {
+        continue;
+    }
+
+    var timestamp = rawCapture.Timeval.Date.ToString("O", CultureInfo.InvariantCulture);
+    var row = string.Join(",",
+        CsvEscape(timestamp),
+        CsvEscape(ipPacket.SourceAddress.ToString()),
+        CsvEscape(ipPacket.DestinationAddress.ToString()),
+        tcpPacket.SequenceNumber.ToString(CultureInfo.InvariantCulture),
+        tcpPacket.AcknowledgmentNumber.ToString(CultureInfo.InvariantCulture),
+        handshakeType);
+
+    writer.WriteLine(row);
+}
+
+Console.WriteLine($"Handshake packet data exported to {Path.GetFullPath(outputFileName)}");
+
+static string? GetHandshakeType(TcpPacket tcpPacket)
+{
+    if (tcpPacket.Syn && tcpPacket.Ack)
+    {
+        return "SYN-ACK";
+    }
+
+    if (tcpPacket.Syn && !tcpPacket.Ack)
+    {
+        return "SYN";
+    }
+
+    if (!tcpPacket.Syn && tcpPacket.Ack)
+    {
+        return "ACK";
+    }
+
+    return null;
+}
+
+static string CsvEscape(string input)
+{
+    if (!input.Contains(',') && !input.Contains('"') && !input.Contains('\n'))
+    {
+        return input;
+    }
+
+    var escaped = input.Replace("\"", "\"\"");
+    return $"\"{escaped}\"";
+}


### PR DESCRIPTION
### Motivation
- Provide a small .NET console utility to parse offline PCAP captures and extract TCP handshake metadata for forensic analysis and downstream processing in R.
- Use established libraries `SharpPcap` and `PacketDotNet` to reliably decode link/IP/TCP layers and TCP flags.

### Description
- Add a new project at `src/PcapHandshakeExporter` with `PcapHandshakeExporter.csproj` that references `SharpPcap` and `PacketDotNet` and targets `net8.0`.
- Implement `Program.cs` to read a PCAP file with `CaptureFileReaderDevice`, parse packets with `PacketDotNet`, extract `IPPacket` and `TcpPacket`, and filter packets that are `SYN`, `SYN-ACK`, or `ACK`.
- Export `Timestamp`, `SourceIP`, `DestinationIP`, `SequenceNumber`, `AcknowledgmentNumber`, and `HandshakeType` to `handshake_data.csv` with CSV escaping.
- Document build and run instructions and the CSV schema in `README.md` under a new "PCAP TCP Handshake Exporter (C#)" section.

### Testing
- Attempted `dotnet build src/PcapHandshakeExporter/PcapHandshakeExporter.csproj`, which failed in this environment because `dotnet` is not installed (`bash: command not found: dotnet`).
- No further automated tests were run in this environment; no unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992700225b48328882a1c1086de495f)