### PR TITLE
Add .NET 8 NFC Worker (Clean Architecture) with PC/SC reader and SignalR hub

### DIFF
--- a/src/NfcReader/NfcReader.Application/Abstractions/INfcReader.cs
+++ b/src/NfcReader/NfcReader.Application/Abstractions/INfcReader.cs
@@ -1,0 +1,12 @@
+using NfcReader.Domain.Entities;
+
+namespace NfcReader.Application.Abstractions;
+
+public interface INfcReader
+{
+    event Func<NfcTagRead, CancellationToken, Task>? TagRead;
+
+    Task StartAsync(CancellationToken cancellationToken);
+
+    Task StopAsync(CancellationToken cancellationToken);
+}

--- a/src/NfcReader/NfcReader.Application/Abstractions/INfcTagStream.cs
+++ b/src/NfcReader/NfcReader.Application/Abstractions/INfcTagStream.cs
@@ -1,0 +1,10 @@
+using NfcReader.Domain.Entities;
+
+namespace NfcReader.Application.Abstractions;
+
+public interface INfcTagStream
+{
+    ValueTask PublishAsync(NfcTagRead tag, CancellationToken cancellationToken);
+
+    IAsyncEnumerable<NfcTagRead> SubscribeAsync(CancellationToken cancellationToken);
+}

--- a/src/NfcReader/NfcReader.Application/Extensions/ServiceCollectionExtensions.cs
+++ b/src/NfcReader/NfcReader.Application/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.DependencyInjection;
+using NfcReader.Application.Abstractions;
+using NfcReader.Application.Services;
+
+namespace NfcReader.Application.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddNfcApplication(this IServiceCollection services)
+    {
+        services.AddSingleton<INfcTagStream, InMemoryNfcTagStream>();
+        services.AddHostedService<NfcReaderHostedService>();
+        return services;
+    }
+}

--- a/src/NfcReader/NfcReader.Application/NfcReader.Application.csproj
+++ b/src/NfcReader/NfcReader.Application/NfcReader.Application.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NfcReader.Domain\NfcReader.Domain.csproj" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+</Project>

--- a/src/NfcReader/NfcReader.Application/Services/InMemoryNfcTagStream.cs
+++ b/src/NfcReader/NfcReader.Application/Services/InMemoryNfcTagStream.cs
@@ -1,0 +1,20 @@
+using System.Threading.Channels;
+using NfcReader.Application.Abstractions;
+using NfcReader.Domain.Entities;
+
+namespace NfcReader.Application.Services;
+
+public sealed class InMemoryNfcTagStream : INfcTagStream
+{
+    private readonly Channel<NfcTagRead> _channel = Channel.CreateUnbounded<NfcTagRead>(new UnboundedChannelOptions
+    {
+        SingleReader = false,
+        SingleWriter = false
+    });
+
+    public ValueTask PublishAsync(NfcTagRead tag, CancellationToken cancellationToken)
+        => _channel.Writer.WriteAsync(tag, cancellationToken);
+
+    public IAsyncEnumerable<NfcTagRead> SubscribeAsync(CancellationToken cancellationToken)
+        => _channel.Reader.ReadAllAsync(cancellationToken);
+}

--- a/src/NfcReader/NfcReader.Application/Services/NfcReaderHostedService.cs
+++ b/src/NfcReader/NfcReader.Application/Services/NfcReaderHostedService.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NfcReader.Application.Abstractions;
+using NfcReader.Domain.Entities;
+
+namespace NfcReader.Application.Services;
+
+public sealed class NfcReaderHostedService(
+    INfcReader nfcReader,
+    INfcTagStream tagStream,
+    ILogger<NfcReaderHostedService> logger) : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        nfcReader.TagRead += OnTagReadAsync;
+        await nfcReader.StartAsync(cancellationToken);
+        logger.LogInformation("NFC reader service started.");
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        nfcReader.TagRead -= OnTagReadAsync;
+        await nfcReader.StopAsync(cancellationToken);
+        logger.LogInformation("NFC reader service stopped.");
+    }
+
+    private async Task OnTagReadAsync(NfcTagRead tag, CancellationToken cancellationToken)
+    {
+        logger.LogInformation(
+            "NFC tag read from {ReaderName}: UID={Uid}, ATR={Atr}",
+            tag.ReaderName,
+            tag.Uid,
+            tag.Atr ?? "<none>");
+
+        await tagStream.PublishAsync(tag, cancellationToken);
+    }
+}

--- a/src/NfcReader/NfcReader.Domain/Entities/NfcTagRead.cs
+++ b/src/NfcReader/NfcReader.Domain/Entities/NfcTagRead.cs
@@ -1,0 +1,8 @@
+namespace NfcReader.Domain.Entities;
+
+public sealed record NfcTagRead(
+    string ReaderName,
+    string Uid,
+    string? Atr,
+    string? RawDataHex,
+    DateTimeOffset ReadAtUtc);

--- a/src/NfcReader/NfcReader.Domain/NfcReader.Domain.csproj
+++ b/src/NfcReader/NfcReader.Domain/NfcReader.Domain.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/NfcReader/NfcReader.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/NfcReader/NfcReader.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.DependencyInjection;
+using NfcReader.Application.Abstractions;
+using NfcReader.Infrastructure.Readers;
+
+namespace NfcReader.Infrastructure.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddNfcInfrastructure(this IServiceCollection services)
+    {
+        services.AddSingleton<INfcReader, PcscNfcReader>();
+        return services;
+    }
+}

--- a/src/NfcReader/NfcReader.Infrastructure/NfcReader.Infrastructure.csproj
+++ b/src/NfcReader/NfcReader.Infrastructure/NfcReader.Infrastructure.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NfcReader.Application\NfcReader.Application.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="PCSC" Version="7.0.5" />
+  </ItemGroup>
+</Project>

--- a/src/NfcReader/NfcReader.Infrastructure/Readers/PcscNfcReader.cs
+++ b/src/NfcReader/NfcReader.Infrastructure/Readers/PcscNfcReader.cs
@@ -1,0 +1,149 @@
+using Microsoft.Extensions.Logging;
+using NfcReader.Application.Abstractions;
+using NfcReader.Domain.Entities;
+using PCSC;
+
+namespace NfcReader.Infrastructure.Readers;
+
+public sealed class PcscNfcReader(ILogger<PcscNfcReader> logger) : INfcReader
+{
+    private readonly ILogger<PcscNfcReader> _logger = logger;
+    private readonly CancellationTokenSource _internalCts = new();
+    private Task? _worker;
+
+    public event Func<NfcTagRead, CancellationToken, Task>? TagRead;
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (_worker is not null)
+        {
+            return Task.CompletedTask;
+        }
+
+        var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _internalCts.Token);
+        _worker = Task.Run(() => PollLoopAsync(linkedCts.Token), linkedCts.Token);
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _internalCts.Cancel();
+
+        if (_worker is null)
+        {
+            return;
+        }
+
+        await Task.WhenAny(_worker, Task.Delay(TimeSpan.FromSeconds(5), cancellationToken));
+    }
+
+    private async Task PollLoopAsync(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                await PollReadersOnceAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected error while polling NFC readers.");
+                await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
+            }
+        }
+    }
+
+    private async Task PollReadersOnceAsync(CancellationToken cancellationToken)
+    {
+        using var context = ContextFactory.Instance.Establish(SCardScope.System);
+        var readers = context.GetReaders();
+
+        if (readers is null || readers.Length == 0)
+        {
+            _logger.LogDebug("No PC/SC readers available.");
+            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+            return;
+        }
+
+        var states = readers
+            .Select(reader => new SCardReaderState
+            {
+                ReaderName = reader,
+                CurrentStateValue = SCRState.Unaware
+            })
+            .ToArray();
+
+        var rc = context.GetStatusChange(SCardReader.Infinite, states);
+        if (rc != SCardError.Success)
+        {
+            _logger.LogWarning("GetStatusChange failed: {Error}", SCardHelper.StringifyError(rc));
+            await Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken);
+            return;
+        }
+
+        foreach (var state in states)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var cardPresent = state.EventState.HasFlag(SCRState.Present);
+            var stateChanged = state.EventState.HasFlag(SCRState.Changed);
+            if (!cardPresent || !stateChanged)
+            {
+                continue;
+            }
+
+            var tag = TryReadTag(context, state.ReaderName);
+            if (tag is null || TagRead is null)
+            {
+                continue;
+            }
+
+            await TagRead.Invoke(tag, cancellationToken);
+        }
+    }
+
+    private NfcTagRead? TryReadTag(ISCardContext context, string readerName)
+    {
+        using var cardReader = new SCardReader(context);
+
+        var connectRc = cardReader.Connect(readerName, SCardShareMode.Shared, SCardProtocol.Any);
+        if (connectRc != SCardError.Success)
+        {
+            _logger.LogWarning(
+                "Failed connecting to reader {ReaderName}. Error: {Error}",
+                readerName,
+                SCardHelper.StringifyError(connectRc));
+            return null;
+        }
+
+        var getUidApdu = new byte[] { 0xFF, 0xCA, 0x00, 0x00, 0x00 };
+        var receiveBuffer = new byte[256];
+
+        var sendPci = SCardPCI.GetPci(cardReader.ActiveProtocol);
+        var transmitRc = cardReader.Transmit(sendPci, getUidApdu, receiveBuffer, out var receivedLength);
+
+        if (transmitRc != SCardError.Success || receivedLength < 2)
+        {
+            _logger.LogWarning(
+                "Failed reading UID from reader {ReaderName}. Error: {Error}",
+                readerName,
+                SCardHelper.StringifyError(transmitRc));
+            return null;
+        }
+
+        var payloadLength = receivedLength - 2;
+        var uidBytes = receiveBuffer.Take(payloadLength).ToArray();
+
+        cardReader.Status(out _, out _, out var protocol, out var atr);
+
+        return new NfcTagRead(
+            readerName,
+            ToHex(uidBytes),
+            atr is { Length: > 0 } ? ToHex(atr) : null,
+            ToHex(receiveBuffer.AsSpan(0, receivedLength)),
+            DateTimeOffset.UtcNow);
+    }
+
+    private static string ToHex(ReadOnlySpan<byte> data)
+        => Convert.ToHexString(data);
+}

--- a/src/NfcReader/NfcReader.Worker/Hubs/NfcHub.cs
+++ b/src/NfcReader/NfcReader.Worker/Hubs/NfcHub.cs
@@ -1,0 +1,7 @@
+using Microsoft.AspNetCore.SignalR;
+
+namespace NfcReader.Worker.Hubs;
+
+public sealed class NfcHub : Hub
+{
+}

--- a/src/NfcReader/NfcReader.Worker/NfcReader.Worker.csproj
+++ b/src/NfcReader/NfcReader.Worker/NfcReader.Worker.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NfcReader.Application\NfcReader.Application.csproj" />
+    <ProjectReference Include="..\NfcReader.Infrastructure\NfcReader.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/NfcReader/NfcReader.Worker/Program.cs
+++ b/src/NfcReader/NfcReader.Worker/Program.cs
@@ -1,0 +1,23 @@
+using NfcReader.Application.Extensions;
+using NfcReader.Infrastructure.Extensions;
+using NfcReader.Worker.Hubs;
+using NfcReader.Worker.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services
+    .AddNfcApplication()
+    .AddNfcInfrastructure();
+
+builder.Services.AddSignalR();
+builder.Services.AddHostedService<SignalRTagBroadcastService>();
+
+var app = builder.Build();
+
+app.UseDefaultFiles();
+app.UseStaticFiles();
+
+app.MapHub<NfcHub>("/hubs/nfc");
+app.MapGet("/health", () => Results.Ok(new { status = "ok" }));
+
+app.Run();

--- a/src/NfcReader/NfcReader.Worker/Services/SignalRTagBroadcastService.cs
+++ b/src/NfcReader/NfcReader.Worker/Services/SignalRTagBroadcastService.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.SignalR;
+using NfcReader.Application.Abstractions;
+using NfcReader.Worker.Hubs;
+
+namespace NfcReader.Worker.Services;
+
+public sealed class SignalRTagBroadcastService(
+    INfcTagStream tagStream,
+    IHubContext<NfcHub> hubContext,
+    ILogger<SignalRTagBroadcastService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await foreach (var tag in tagStream.SubscribeAsync(stoppingToken))
+        {
+            await hubContext.Clients.All.SendAsync("TagRead", tag, stoppingToken);
+            logger.LogInformation("Broadcasted tag {Uid} from reader {ReaderName}", tag.Uid, tag.ReaderName);
+        }
+    }
+}

--- a/src/NfcReader/NfcReader.Worker/appsettings.json
+++ b/src/NfcReader/NfcReader.Worker/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/NfcReader/NfcReader.Worker/wwwroot/index.html
+++ b/src/NfcReader/NfcReader.Worker/wwwroot/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>NFC Reader Dashboard</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    #events { margin-top: 1rem; }
+    .event { padding: 0.5rem; border-bottom: 1px solid #ddd; }
+  </style>
+</head>
+<body>
+  <h1>NFC Reader Events</h1>
+  <p>Listening for NFC tag events from SignalR hub...</p>
+  <div id="events"></div>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/8.0.7/signalr.min.js"></script>
+  <script>
+    const events = document.getElementById('events');
+    const connection = new signalR.HubConnectionBuilder().withUrl('/hubs/nfc').build();
+
+    connection.on('TagRead', (tag) => {
+      const item = document.createElement('div');
+      item.className = 'event';
+      item.textContent = `${tag.readAtUtc} | Reader=${tag.readerName} | UID=${tag.uid} | ATR=${tag.atr ?? 'N/A'}`;
+      events.prepend(item);
+    });
+
+    connection.start().catch(err => {
+      const item = document.createElement('div');
+      item.className = 'event';
+      item.textContent = `Failed to connect: ${err}`;
+      events.prepend(item);
+    });
+  </script>
+</body>
+</html>

--- a/src/NfcReader/NfcReader.sln
+++ b/src/NfcReader/NfcReader.sln
@@ -1,0 +1,39 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NfcReader.Domain", "NfcReader.Domain\NfcReader.Domain.csproj", "{E85F5EAA-ECA0-4F5F-8C1D-61A49A2C91B7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NfcReader.Application", "NfcReader.Application\NfcReader.Application.csproj", "{BF9490D1-8A8E-4FAD-BFC2-44A4E24D81E2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NfcReader.Infrastructure", "NfcReader.Infrastructure\NfcReader.Infrastructure.csproj", "{398D7677-8F55-4628-BEC4-E4309636AC05}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NfcReader.Worker", "NfcReader.Worker\NfcReader.Worker.csproj", "{AEDEED84-68CC-4B36-AF89-E47EA50303B4}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E85F5EAA-ECA0-4F5F-8C1D-61A49A2C91B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E85F5EAA-ECA0-4F5F-8C1D-61A49A2C91B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E85F5EAA-ECA0-4F5F-8C1D-61A49A2C91B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E85F5EAA-ECA0-4F5F-8C1D-61A49A2C91B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BF9490D1-8A8E-4FAD-BFC2-44A4E24D81E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF9490D1-8A8E-4FAD-BFC2-44A4E24D81E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF9490D1-8A8E-4FAD-BFC2-44A4E24D81E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF9490D1-8A8E-4FAD-BFC2-44A4E24D81E2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{398D7677-8F55-4628-BEC4-E4309636AC05}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{398D7677-8F55-4628-BEC4-E4309636AC05}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{398D7677-8F55-4628-BEC4-E4309636AC05}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{398D7677-8F55-4628-BEC4-E4309636AC05}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AEDEED84-68CC-4B36-AF89-E47EA50303B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AEDEED84-68CC-4B36-AF89-E47EA50303B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AEDEED84-68CC-4B36-AF89-E47EA50303B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AEDEED84-68CC-4B36-AF89-E47EA50303B4}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/NfcReader/README.md
+++ b/src/NfcReader/README.md
@@ -1,0 +1,26 @@
+# NFC Reader Worker (.NET 8)
+
+This solution provides a Clean Architecture-based NFC reader using PC/SC and SignalR.
+
+## Projects
+
+- **NfcReader.Domain**: Domain model (`NfcTagRead`).
+- **NfcReader.Application**: Abstractions and orchestration (`INfcReader`, in-memory stream, hosted service).
+- **NfcReader.Infrastructure**: PC/SC implementation (`PcscNfcReader`) that reads card UIDs.
+- **NfcReader.Worker**: Console/worker host with ASP.NET Core SignalR hub and static browser UI.
+
+## Runtime flow
+
+1. `PcscNfcReader` polls PC/SC readers and emits tag reads.
+2. `NfcReaderHostedService` publishes tag events into an application stream.
+3. `SignalRTagBroadcastService` consumes stream events and broadcasts `TagRead` to all hub clients.
+4. Browser clients connect to `/hubs/nfc` and render incoming tag data.
+
+## Run
+
+```bash
+dotnet restore src/NfcReader/NfcReader.sln
+dotnet run --project src/NfcReader/NfcReader.Worker/NfcReader.Worker.csproj
+```
+
+Open http://localhost:5000 to view live events.


### PR DESCRIPTION
### Motivation
- Provide a lightweight worker that reads NFC tags via PC/SC and broadcasts tag events to a browser over SignalR for live monitoring. 
- Structure the code using Clean Architecture so reader logic can be tested and replaced independently of the host and UI.

### Description
- Add a new `src/NfcReader` solution targeting `net8.0` containing `NfcReader.Domain`, `NfcReader.Application`, `NfcReader.Infrastructure`, and `NfcReader.Worker` projects. 
- Implement domain model `NfcTagRead` and application abstractions `INfcReader` and `INfcTagStream` plus an in-memory channel stream and a hosted service to bridge reader events to the stream. 
- Implement `PcscNfcReader` in Infrastructure using the `PCSC` package to poll readers, detect card presence, send `FF CA 00 00 00` APDU for UID, and construct `NfcTagRead` objects. 
- Implement an ASP.NET Core worker with a `NfcHub` SignalR hub, a `SignalRTagBroadcastService` background service that broadcasts `TagRead` events, a static `wwwroot/index.html` dashboard, DI extension helpers, and `README.md` with run instructions. 

### Testing
- Attempted to build the solution with `dotnet build src/NfcReader/NfcReader.sln`, but the environment lacks the .NET SDK so the build could not run (`bash: dotnet: command not found`).
- Attempted to validate the dashboard with a Playwright script pointing at `http://127.0.0.1:5000`, but no running service responded (`net::ERR_EMPTY_RESPONSE`).
- No automated unit tests were included in this change, so functional validation requires a host environment with .NET 8+ and access to PC/SC readers to run `dotnet run --project src/NfcReader/NfcReader.Worker/NfcReader.Worker.csproj`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69927260d4dc83289edbf1d51dcd84f8)