### PR TITLE
Add modular Java CLI dispatcher example with registry and error handling

### DIFF
--- a/docs/cli/dispatcher/Command.java
+++ b/docs/cli/dispatcher/Command.java
@@ -1,0 +1,10 @@
+package docs.cli.dispatcher;
+
+import java.util.List;
+
+/**
+ * Shared contract for all commands that can be registered with the Dispatcher.
+ */
+public interface Command {
+    void execute(List<String> args) throws CommandException;
+}

--- a/docs/cli/dispatcher/CommandException.java
+++ b/docs/cli/dispatcher/CommandException.java
@@ -1,0 +1,14 @@
+package docs.cli.dispatcher;
+
+/**
+ * Checked exception used for command-level failures and usage errors.
+ */
+public class CommandException extends Exception {
+    public CommandException(String message) {
+        super(message);
+    }
+
+    public CommandException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/docs/cli/dispatcher/Dispatcher.java
+++ b/docs/cli/dispatcher/Dispatcher.java
@@ -1,0 +1,105 @@
+package docs.cli.dispatcher;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Hashtable;
+import java.util.List;
+
+/**
+ * Main dispatcher that routes first-token command names to command objects.
+ */
+public class Dispatcher {
+    private final Hashtable<String, Command> commandRegistry = new Hashtable<>();
+
+    public Dispatcher() {
+        // Register commands here. Extensibility is achieved by adding more entries.
+        register("greet", new GreetCommand());
+    }
+
+    public void register(String token, Command command) {
+        commandRegistry.put(token, command);
+    }
+
+    public void dispatch(String[] rawArgs) {
+        ParsedInput parsedInput = parseGlobalOptions(rawArgs);
+
+        if (parsedInput.showHelp || parsedInput.commandToken == null) {
+            usage();
+            return;
+        }
+
+        Command command = commandRegistry.get(parsedInput.commandToken);
+        if (command == null) {
+            System.err.printf("Unknown command: %s%n", parsedInput.commandToken);
+            usage();
+            return;
+        }
+
+        try {
+            command.execute(parsedInput.commandArgs);
+        } catch (CommandException ex) {
+            System.err.printf("Command '%s' failed: %s%n", parsedInput.commandToken, ex.getMessage());
+            usage();
+        } catch (RuntimeException ex) {
+            // Catch unexpected runtime errors and surface a friendly message.
+            System.err.printf("Unexpected error while running '%s': %s%n", parsedInput.commandToken, ex.getMessage());
+        }
+    }
+
+    /**
+     * Simplified "getopts"-style global option parsing.
+     *
+     * Supported global options:
+     *   -h, --help      Show usage.
+     *   --verbose       Example global flag (available for future expansion).
+     */
+    private ParsedInput parseGlobalOptions(String[] rawArgs) {
+        ParsedInput parsed = new ParsedInput();
+        List<String> tokens = new ArrayList<>(Arrays.asList(rawArgs));
+
+        while (!tokens.isEmpty() && tokens.get(0).startsWith("-")) {
+            String option = tokens.remove(0);
+            switch (option) {
+                case "-h":
+                case "--help":
+                    parsed.showHelp = true;
+                    return parsed;
+                case "--verbose":
+                    parsed.verbose = true;
+                    break;
+                default:
+                    System.err.printf("Unknown global option: %s%n", option);
+                    parsed.showHelp = true;
+                    return parsed;
+            }
+        }
+
+        if (!tokens.isEmpty()) {
+            parsed.commandToken = tokens.remove(0);
+            parsed.commandArgs = tokens;
+        }
+
+        return parsed;
+    }
+
+    private void usage() {
+        System.err.println("Usage: <program> [global-options] <command> [command-args]");
+        System.err.println("Global options:");
+        System.err.println("  -h, --help      Show this help text");
+        System.err.println("  --verbose       Enable verbose output");
+        System.err.println("Commands:");
+        System.err.println("  greet <name>    Print a greeting for <name>");
+    }
+
+    public static void main(String[] args) {
+        Dispatcher dispatcher = new Dispatcher();
+        dispatcher.dispatch(args);
+    }
+
+    private static class ParsedInput {
+        private boolean showHelp;
+        private boolean verbose;
+        private String commandToken;
+        private List<String> commandArgs = new ArrayList<>();
+    }
+}

--- a/docs/cli/dispatcher/GreetCommand.java
+++ b/docs/cli/dispatcher/GreetCommand.java
@@ -1,0 +1,21 @@
+package docs.cli.dispatcher;
+
+import java.util.List;
+
+/**
+ * Example command implementation.
+ *
+ * Usage:
+ *   greet <name>
+ */
+public class GreetCommand implements Command {
+    @Override
+    public void execute(List<String> args) throws CommandException {
+        if (args.isEmpty()) {
+            throw new CommandException("Missing required argument: <name>");
+        }
+
+        String name = args.get(0);
+        System.out.printf("Hello, %s!%n", name);
+    }
+}

--- a/docs/cli/dispatcher/README.md
+++ b/docs/cli/dispatcher/README.md
@@ -1,0 +1,23 @@
+# Modular CLI Dispatcher Example
+
+This example demonstrates a command-driven dispatcher with:
+
+- `Command` interface: `execute(List<String> args) throws CommandException`
+- Registry based on `Hashtable<String, Command>`
+- Simplified getopts-style global options parsing in the dispatcher
+- `CommandException`-based error handling with centralized `usage()`
+- Easy extensibility by registering new commands via `register(token, command)`
+
+## Files
+
+- `Command.java` - command interface
+- `CommandException.java` - custom checked exception type
+- `GreetCommand.java` - sample command implementation
+- `Dispatcher.java` - main registry + routing + global option parser
+
+## Compile and run
+
+```bash
+javac docs/cli/dispatcher/*.java
+java docs.cli.dispatcher.Dispatcher greet Alice
+```


### PR DESCRIPTION
### Motivation
- Provide a modular, extensible command-line dispatcher pattern in Java that allows new commands to be added by registration without modifying core dispatcher logic.
- Offer a clear command contract and a checked exception type to surface command-level usage and execution errors uniformly.
- Demonstrate a compact example that includes global option parsing and friendly error/usage reporting to serve as a template for other commands.

### Description
- Add `Command` interface with the single method `void execute(List<String> args) throws CommandException` as the shared command contract.
- Introduce `CommandException` as a checked exception type for command-level failures and usage errors.
- Implement `Dispatcher` which uses a `Hashtable<String, Command>` registry, a simplified getopts-style global option parser (`-h/--help`, `--verbose`), and centralized `usage()` plus try/catch around `execute()` for friendly error reporting.
- Provide `GreetCommand` as a sample command and include `docs/cli/dispatcher/README.md` with compile and run instructions.

### Testing
- Compiled the example with `javac docs/cli/dispatcher/*.java`, which succeeded without errors.
- Executed `java docs.cli.dispatcher.Dispatcher greet Alice` and verified it printed `Hello, Alice!`, confirming dispatch, argument handling, and error-free execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699275c7af3883289bef76013e293a15)