### PR TITLE
Add production endpoint, syscall, and API key modules

### DIFF
--- a/docs/cli/dispatcher/README.md
+++ b/docs/cli/dispatcher/README.md
@@ -21,3 +21,8 @@ This example demonstrates a command-driven dispatcher with:
 javac docs/cli/dispatcher/*.java
 java docs.cli.dispatcher.Dispatcher greet Alice
 ```
+
+## IAM policy parser (Python)
+
+Production parser entrypoint: `docs/cli/dispatcher/iam_policy_parser.py` (stdout emits one JSON object only).
+

--- a/docs/cli/dispatcher/iam-integration-production.md
+++ b/docs/cli/dispatcher/iam-integration-production.md
@@ -1,0 +1,16 @@
+# IAM Integration Production Notes
+
+This deployment includes additional Python integration modules:
+
+- `iato_ops/api_keys.py` for environment-based API key loading.
+- `iato_ops/endpoints.py` for authenticated endpoint calls.
+- `iato_ops/syscalls.py` for runtime syscall metadata snapshots.
+
+## API Key Requirements
+
+Set the following environment variables in deployment runtime:
+
+- `IATO_POLICY_SERVICE_API_KEY`
+- `IATO_TELEMETRY_API_KEY`
+
+No API keys are committed to source control.

--- a/docs/cli/dispatcher/iam_policy_parser.py
+++ b/docs/cli/dispatcher/iam_policy_parser.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Compatibility wrapper for deployed IAM policy parser."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from iato_ops.iam_policy_parser import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/iato_ops/__init__.py
+++ b/iato_ops/__init__.py
@@ -1,0 +1,8 @@
+"""iato_ops package."""
+
+__all__ = [
+    "iam_policy_parser",
+    "api_keys",
+    "endpoints",
+    "syscalls",
+]

--- a/iato_ops/api_keys.py
+++ b/iato_ops/api_keys.py
@@ -1,0 +1,33 @@
+"""API key loading utilities for production endpoint integrations."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class APIKeyConfig:
+    """Holds API key environment variable names."""
+
+    policy_service_key_env: str = "IATO_POLICY_SERVICE_API_KEY"
+    telemetry_service_key_env: str = "IATO_TELEMETRY_API_KEY"
+
+
+class APIKeyManager:
+    """Loads API keys from environment variables without storing plaintext in files."""
+
+    def __init__(self, config: APIKeyConfig | None = None) -> None:
+        self.config = config or APIKeyConfig()
+
+    def get_policy_service_key(self) -> str:
+        return self._read_key(self.config.policy_service_key_env)
+
+    def get_telemetry_service_key(self) -> str:
+        return self._read_key(self.config.telemetry_service_key_env)
+
+    def _read_key(self, env_name: str) -> str:
+        value = os.getenv(env_name, "").strip()
+        if not value:
+            raise ValueError(f"Missing required API key in environment variable: {env_name}")
+        return value

--- a/iato_ops/endpoints.py
+++ b/iato_ops/endpoints.py
@@ -1,0 +1,48 @@
+"""Endpoint client primitives for integrating policy and telemetry services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import requests
+
+
+@dataclass(frozen=True)
+class EndpointConfig:
+    """Endpoint base URLs for service integration."""
+
+    policy_base_url: str
+    telemetry_base_url: str
+    timeout_seconds: int = 10
+
+
+class EndpointClient:
+    """Minimal endpoint client for JSON APIs used by the dispatcher toolchain."""
+
+    def __init__(self, config: EndpointConfig) -> None:
+        self.config = config
+
+    def fetch_policy_document(self, policy_id: str, api_key: str) -> dict[str, Any]:
+        response = requests.get(
+            f"{self.config.policy_base_url.rstrip('/')}/policies/{policy_id}",
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=self.config.timeout_seconds,
+        )
+        response.raise_for_status()
+        return self._require_json_object(response.json(), "policy")
+
+    def submit_risk_result(self, payload: dict[str, Any], api_key: str) -> dict[str, Any]:
+        response = requests.post(
+            f"{self.config.telemetry_base_url.rstrip('/')}/risk-results",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json=payload,
+            timeout=self.config.timeout_seconds,
+        )
+        response.raise_for_status()
+        return self._require_json_object(response.json(), "telemetry")
+
+    def _require_json_object(self, value: Any, endpoint_name: str) -> dict[str, Any]:
+        if not isinstance(value, dict):
+            raise ValueError(f"{endpoint_name} endpoint did not return a JSON object")
+        return value

--- a/iato_ops/iam_policy_parser.py
+++ b/iato_ops/iam_policy_parser.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Production IAM policy parser for C-based dispatchers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RiskWeights:
+    """Risk score weights for critical findings."""
+
+    privilege_escalation: int = 40
+    data_exposure: int = 30
+    insecure_trust: int = 40
+
+
+class IAMParser:
+    """Parse IAM policies and emit deterministic, JSON-safe risk output."""
+
+    PRIV_ESCALATION_ACTIONS = {
+        "iam:createaccesskey",
+        "iam:updateassumerolepolicy",
+    }
+    DATA_EXPOSURE_ACTIONS = {
+        "s3:putbucketpolicy",
+        "s3:getbucketlocation",
+    }
+
+    def __init__(self, policy: dict[str, Any], weights: RiskWeights | None = None) -> None:
+        if not isinstance(policy, dict):
+            raise ValueError("Policy must be a JSON object.")
+        self.policy = policy
+        self.weights = weights or RiskWeights()
+
+    def analyze(self) -> dict[str, Any]:
+        statements = self._normalize_statements(self.policy.get("Statement", []))
+        expanded_actions: set[str] = set()
+        raw_action_patterns: set[str] = set()
+
+        has_priv_escalation = False
+        has_data_exposure = False
+        has_insecure_trust = False
+
+        for statement in statements:
+            if statement.get("Effect", "Allow") != "Allow":
+                continue
+
+            raw_action_patterns.update(self._extract_raw_actions(statement))
+            statement_actions = self._expand_statement_actions(statement)
+            expanded_actions.update(statement_actions)
+
+            has_priv_escalation = has_priv_escalation or bool(
+                statement_actions & self.PRIV_ESCALATION_ACTIONS
+            )
+            has_data_exposure = has_data_exposure or bool(
+                statement_actions & self.DATA_EXPOSURE_ACTIONS
+            )
+            has_insecure_trust = has_insecure_trust or self._has_insecure_trust(statement)
+
+        is_admin = self._is_admin_policy(expanded_actions, raw_action_patterns)
+        risk_warnings = self._build_risk_warnings(
+            expanded_actions,
+            has_priv_escalation,
+            has_data_exposure,
+            has_insecure_trust,
+        )
+
+        risk_score = self._build_risk_score(
+            is_admin=is_admin,
+            has_priv_escalation=has_priv_escalation,
+            has_data_exposure=has_data_exposure,
+            has_insecure_trust=has_insecure_trust,
+        )
+
+        return {
+            "is_admin": is_admin,
+            "risk_score": risk_score,
+            "risk_warnings": risk_warnings,
+        }
+
+    def _normalize_statements(self, statements: Any) -> list[dict[str, Any]]:
+        if isinstance(statements, dict):
+            statements = [statements]
+        if not isinstance(statements, list):
+            raise ValueError("Policy Statement must be an object or array.")
+        return [statement for statement in statements if isinstance(statement, dict)]
+
+    def _extract_raw_actions(self, statement: dict[str, Any]) -> set[str]:
+        raw_actions = statement.get("Action", [])
+        actions = [raw_actions] if isinstance(raw_actions, str) else raw_actions
+        if not isinstance(actions, list):
+            return set()
+        return {action.lower() for action in actions if isinstance(action, str)}
+
+    def _expand_statement_actions(self, statement: dict[str, Any]) -> set[str]:
+        actions = list(self._extract_raw_actions(statement))
+        if not isinstance(actions, list):
+            return set()
+
+        try:
+            from policyuniverse.expander import expand_action
+        except Exception as exc:  # pylint: disable=broad-except
+            raise RuntimeError(
+                "policyuniverse dependency is required for wildcard expansion"
+            ) from exc
+
+        expanded: set[str] = set()
+        for action in actions:
+            if not isinstance(action, str):
+                continue
+            for resolved in expand_action(action):
+                expanded.add(str(resolved).lower())
+        return expanded
+
+    def _has_insecure_trust(self, statement: dict[str, Any]) -> bool:
+        actions = statement.get("Action", [])
+        if isinstance(actions, str):
+            actions = [actions]
+        if not isinstance(actions, list):
+            return False
+
+        has_assume_role = any(
+            isinstance(action, str) and action.lower() == "sts:assumerole"
+            for action in actions
+        )
+        return has_assume_role and self._principal_contains_wildcard(statement.get("Principal"))
+
+    def _principal_contains_wildcard(self, principal: Any) -> bool:
+        if isinstance(principal, str):
+            return "*" in principal
+        if isinstance(principal, list):
+            return any(self._principal_contains_wildcard(entry) for entry in principal)
+        if isinstance(principal, dict):
+            return any(self._principal_contains_wildcard(value) for value in principal.values())
+        return False
+
+    def _is_admin_policy(
+        self,
+        expanded_actions: set[str],
+        raw_action_patterns: set[str],
+    ) -> bool:
+        return any(token in {"*", "iam:*"} for token in expanded_actions | raw_action_patterns)
+
+    def _build_risk_warnings(
+        self,
+        expanded_actions: set[str],
+        has_priv_escalation: bool,
+        has_data_exposure: bool,
+        has_insecure_trust: bool,
+    ) -> list[str]:
+        warnings: list[str] = []
+        if has_priv_escalation:
+            matched = sorted(expanded_actions & self.PRIV_ESCALATION_ACTIONS)
+            warnings.append(
+                f"Critical: Privilege escalation permissions present: {', '.join(matched)}."
+            )
+        if has_data_exposure:
+            matched = sorted(expanded_actions & self.DATA_EXPOSURE_ACTIONS)
+            warnings.append(
+                f"Critical: Data exposure permissions present: {', '.join(matched)}."
+            )
+        if has_insecure_trust:
+            warnings.append(
+                "Critical: Insecure trust policy allows sts:AssumeRole with wildcard principal."
+            )
+        return warnings
+
+    def _build_risk_score(
+        self,
+        *,
+        is_admin: bool,
+        has_priv_escalation: bool,
+        has_data_exposure: bool,
+        has_insecure_trust: bool,
+    ) -> int:
+        score = 0
+        if is_admin:
+            score += 30
+        if has_priv_escalation:
+            score += self.weights.privilege_escalation
+        if has_data_exposure:
+            score += self.weights.data_exposure
+        if has_insecure_trust:
+            score += self.weights.insecure_trust
+        return min(100, score)
+
+
+def _build_cli_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="iam-policy-parser", add_help=True)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--policy", type=str, help="Raw IAM policy JSON string")
+    source.add_argument("--file", type=str, help="Path to IAM policy JSON file")
+    return parser
+
+
+def _load_policy_from_args(args: argparse.Namespace) -> dict[str, Any]:
+    if args.policy:
+        return json.loads(args.policy)
+    with open(args.file, "r", encoding="utf-8") as file_handle:
+        return json.load(file_handle)
+
+
+def main() -> int:
+    try:
+        parser = _build_cli_parser()
+        args = parser.parse_args()
+        policy = _load_policy_from_args(args)
+        result = IAMParser(policy).analyze()
+        sys.stdout.write(json.dumps(result, separators=(",", ":")))
+        return 0
+    except Exception as exc:  # pylint: disable=broad-except
+        sys.stdout.write(json.dumps({"error": str(exc)}, separators=(",", ":")))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/iato_ops/syscalls.py
+++ b/iato_ops/syscalls.py
@@ -1,0 +1,26 @@
+"""System-call-style runtime metadata helpers for low-level dispatcher integrations."""
+
+from __future__ import annotations
+
+import os
+import platform
+import time
+from typing import Any
+
+
+def collect_runtime_syscalls() -> dict[str, Any]:
+    """Collect a minimal, JSON-serializable syscall/runtime metadata snapshot."""
+
+    return {
+        "pid": os.getpid(),
+        "ppid": os.getppid(),
+        "cwd": os.getcwd(),
+        "uname": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "version": platform.version(),
+            "machine": platform.machine(),
+        },
+        "monotonic_ns": time.monotonic_ns(),
+        "time_ns": time.time_ns(),
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,16 +2,31 @@
 name = "iato-ops"
 version = "0.1.0"
 description = "Operational tooling for the IATO Docker and S3-backed Drupal stack"
+readme = "README.md"
 requires-python = ">=3.11"
+keywords = [
+  "iam-security",
+  "policy-analysis",
+  "risk-scoring",
+  "cloud-governance",
+  "c-dispatcher"
+]
 dependencies = [
   "boto3>=1.34",
   "pyyaml>=6.0",
-  "requests>=2.32"
+  "requests>=2.32",
+  "policyuniverse>=1.5"
 ]
+
+[project.scripts]
+iam-policy-parser = "iato_ops.iam_policy_parser:main"
 
 [build-system]
 requires = ["hatchling>=1.26.0"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["iato_ops"]
 
 [tool.conda-lock]
 channels = ["conda-forge"]


### PR DESCRIPTION
### Motivation
- Provide production-safe integrations for fetching IAM policies and submitting telemetry without committing plaintext API keys. 
- Expose a minimal, JSON-serializable runtime metadata snapshot for low-level dispatcher telemetry and debugging. 

### Description
- Add `iato_ops/api_keys.py` implementing `APIKeyManager` which reads and validates API keys from environment variables (`IATO_POLICY_SERVICE_API_KEY`, `IATO_TELEMETRY_API_KEY`).
- Add `iato_ops/endpoints.py` implementing `EndpointClient` and `EndpointConfig` with `fetch_policy_document` and `submit_risk_result` methods that use `requests` with timeouts, authorization headers, and JSON-object validation. 
- Add `iato_ops/syscalls.py` providing `collect_runtime_syscalls()` that returns PID/PPID/CWD/uname/monotonic/time fields as a JSON-serializable dict. 
- Export the new modules via `iato_ops/__init__.py` and add deployment notes in `docs/cli/dispatcher/iam-integration-production.md` describing the new modules and required environment variables. 

### Testing
- Compiled Python sources with `python -m py_compile iato_ops/iam_policy_parser.py iato_ops/api_keys.py iato_ops/endpoints.py iato_ops/syscalls.py docs/cli/dispatcher/iam_policy_parser.py`, which completed successfully. 
- Ran the dispatcher wrapper with a missing-file case using `python docs/cli/dispatcher/iam_policy_parser.py --file /tmp/does-not-exist.json`, which emitted a JSON error payload and returned a non-zero exit code as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992788815e88328adc00e72e174ddba)