### PR TITLE
test: add missing iato_ops tests and fix test configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ platforms = ["linux-64", "osx-64"]
 
 [tool.conda-lock.dependencies]
 python = "3.11"
-pip = "*"
 
 [tool.conda-lock.dependencies.pip]
 iato-ops = {path = ".", editable = true}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test-results.md
+++ b/tests/test-results.md
@@ -1,0 +1,41 @@
+# Test Run Results
+
+Date (UTC): 2026-02-16T02:16:30Z
+
+## Commands Executed
+
+### 1) `pytest -q`
+- **Exit code:** `0`
+- **Result:** Passed.
+- **Output:**
+
+```text
+..........                                                               [100%]
+10 passed in 0.08s
+```
+
+### 2) `dotnet test src/NfcReader/NfcReader.sln`
+- **Exit code:** `127`
+- **Result:** Could not execute in this environment (missing .NET CLI).
+- **Output:**
+
+```text
+bash: command not found: dotnet
+```
+
+### 3) `python -m unittest discover`
+- **Exit code:** `0`
+- **Result:** Command succeeded, but no `unittest`-style tests were discovered.
+- **Output:**
+
+```text
+----------------------------------------------------------------------
+Ran 0 tests in 0.000s
+
+OK
+```
+
+## Summary
+- Added and ran Python unit tests for the recently introduced `iato_ops` components.
+- `pytest` now executes successfully with `10` passing tests.
+- .NET tests remain blocked by missing `dotnet` in the current runtime environment.

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -1,0 +1,19 @@
+import pytest
+
+from iato_ops.api_keys import APIKeyManager
+
+
+def test_get_policy_service_key_reads_env(monkeypatch):
+    monkeypatch.setenv("IATO_POLICY_SERVICE_API_KEY", "policy-secret")
+    assert APIKeyManager().get_policy_service_key() == "policy-secret"
+
+
+def test_get_telemetry_service_key_reads_env(monkeypatch):
+    monkeypatch.setenv("IATO_TELEMETRY_API_KEY", "telemetry-secret")
+    assert APIKeyManager().get_telemetry_service_key() == "telemetry-secret"
+
+
+def test_missing_key_raises_value_error(monkeypatch):
+    monkeypatch.delenv("IATO_POLICY_SERVICE_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="IATO_POLICY_SERVICE_API_KEY"):
+        APIKeyManager().get_policy_service_key()

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,81 @@
+import sys
+import types
+
+import pytest
+
+# Provide a lightweight requests shim for environments without external deps.
+if "requests" not in sys.modules:
+    requests_stub = types.ModuleType("requests")
+    requests_stub.get = None
+    requests_stub.post = None
+    sys.modules["requests"] = requests_stub
+
+from iato_ops.endpoints import EndpointClient, EndpointConfig
+
+
+class DummyResponse:
+    def __init__(self, payload, status_ok=True):
+        self._payload = payload
+        self._status_ok = status_ok
+
+    def raise_for_status(self):
+        if not self._status_ok:
+            raise RuntimeError("http error")
+
+    def json(self):
+        return self._payload
+
+
+def test_fetch_policy_document_calls_get(monkeypatch):
+    captured = {}
+
+    def fake_get(url, headers, timeout):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return DummyResponse({"id": "abc"})
+
+    monkeypatch.setattr("iato_ops.endpoints.requests.get", fake_get)
+
+    client = EndpointClient(
+        EndpointConfig(policy_base_url="https://policy.local", telemetry_base_url="https://tel.local")
+    )
+    result = client.fetch_policy_document("abc", "token")
+
+    assert result == {"id": "abc"}
+    assert captured["url"] == "https://policy.local/policies/abc"
+    assert captured["headers"]["Authorization"] == "Bearer token"
+    assert captured["timeout"] == 10
+
+
+def test_submit_risk_result_calls_post(monkeypatch):
+    captured = {}
+
+    def fake_post(url, headers, json, timeout):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        captured["timeout"] = timeout
+        return DummyResponse({"accepted": True})
+
+    monkeypatch.setattr("iato_ops.endpoints.requests.post", fake_post)
+
+    client = EndpointClient(
+        EndpointConfig(policy_base_url="https://policy.local", telemetry_base_url="https://tel.local")
+    )
+    payload = {"risk": 80}
+    result = client.submit_risk_result(payload, "token")
+
+    assert result == {"accepted": True}
+    assert captured["url"] == "https://tel.local/risk-results"
+    assert captured["headers"]["Authorization"] == "Bearer token"
+    assert captured["json"] == payload
+
+
+def test_non_object_json_raises():
+    client = EndpointClient(
+        EndpointConfig(policy_base_url="https://policy.local", telemetry_base_url="https://tel.local")
+    )
+
+    with pytest.raises(ValueError, match="did not return a JSON object"):
+        client._require_json_object([1, 2], "policy")

--- a/tests/test_iam_policy_parser.py
+++ b/tests/test_iam_policy_parser.py
@@ -1,0 +1,60 @@
+import json
+import types
+
+import pytest
+
+from iato_ops.iam_policy_parser import IAMParser, main
+
+
+@pytest.fixture(autouse=True)
+def fake_policyuniverse(monkeypatch):
+    module = types.ModuleType("policyuniverse.expander")
+
+    def expand_action(action):
+        mapping = {
+            "iam:*": ["iam:createaccesskey", "iam:updateassumerolepolicy"],
+            "s3:*": ["s3:putbucketpolicy", "s3:getbucketlocation"],
+        }
+        return mapping.get(action.lower(), [action.lower()])
+
+    module.expand_action = expand_action
+    monkeypatch.setitem(__import__("sys").modules, "policyuniverse.expander", module)
+
+
+def test_analyze_detects_admin_and_risks():
+    policy = {
+        "Statement": [
+            {"Effect": "Allow", "Action": ["iam:*", "s3:*", "sts:AssumeRole"], "Principal": "*"}
+        ]
+    }
+
+    result = IAMParser(policy).analyze()
+
+    assert result["is_admin"] is True
+    assert result["risk_score"] == 100
+    assert len(result["risk_warnings"]) == 3
+
+
+def test_main_with_policy_argument(monkeypatch, capsys):
+    policy = {"Statement": {"Effect": "Allow", "Action": "s3:PutBucketPolicy"}}
+    monkeypatch.setattr(
+        "sys.argv",
+        ["iam-policy-parser", "--policy", json.dumps(policy)],
+    )
+
+    code = main()
+    out = capsys.readouterr().out
+
+    assert code == 0
+    parsed = json.loads(out)
+    assert parsed["risk_score"] >= 30
+
+
+def test_main_returns_error_for_invalid_json(monkeypatch, capsys):
+    monkeypatch.setattr("sys.argv", ["iam-policy-parser", "--policy", "{"])
+
+    code = main()
+    out = capsys.readouterr().out
+
+    assert code == 1
+    assert "error" in json.loads(out)

--- a/tests/test_syscalls.py
+++ b/tests/test_syscalls.py
@@ -1,0 +1,15 @@
+from iato_ops.syscalls import collect_runtime_syscalls
+
+
+def test_collect_runtime_syscalls_shape():
+    data = collect_runtime_syscalls()
+
+    assert isinstance(data["pid"], int)
+    assert isinstance(data["ppid"], int)
+    assert isinstance(data["cwd"], str)
+    assert isinstance(data["monotonic_ns"], int)
+    assert isinstance(data["time_ns"], int)
+
+    uname = data["uname"]
+    assert set(uname.keys()) == {"system", "release", "version", "machine"}
+    assert all(isinstance(uname[key], str) for key in uname)


### PR DESCRIPTION
### Motivation
- Ensure the recently added `iato_ops` modules are validated by automated tests and fix test collection issues that prevented `pytest` from running.
- Make tests robust in restricted environments where external packages or the .NET CLI cannot be installed.

### Description
- Fixed the project metadata used by test tooling by removing the stray `pip = "*"` entry from `[tool.conda-lock.dependencies]` in `pyproject.toml` so test tools parse project metadata correctly.
- Added `tests/conftest.py` to insert the repository root onto `sys.path` during test collection so `iato_ops` imports resolve consistently.
- Added pytest suites covering `APIKeyManager` (`tests/test_api_keys.py`), runtime metadata collector (`tests/test_syscalls.py`), endpoint client behavior (`tests/test_endpoints.py`) with a lightweight `requests` shim for offline environments, and `IAMParser` analysis and CLI behavior (`tests/test_iam_policy_parser.py`).
- Added `tests/test-results.md` documenting the test run outputs and environment limitations.

### Testing
- Ran `pytest -q`, which passed with `10 passed` tests against the new Python test suite.
- Attempted `python -m pip install requests policyuniverse` failed due to the environment network/proxy constraints, so the `requests` dependency was shimmed in tests and `policyuniverse` was stubbed in the IAM parser tests; `pytest` still passed.
- Ran `dotnet test src/NfcReader/NfcReader.sln`, which could not be executed in this environment because the `dotnet` CLI is not installed (exit code `127`).
- Ran `python -m unittest discover`, which succeeded but found `0` unittest-style tests (no change to existing `unittest` suites).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69927c744fc08328bc90ad5cb3d350a9)