### PR TITLE
docs: add rebase conflict issue log documenting resolution and follow-ups

### DIFF
--- a/docs/rebase-conflict-issue-log.md
+++ b/docs/rebase-conflict-issue-log.md
@@ -1,0 +1,43 @@
+# Rebase Conflict Resolution Issue Log
+
+This document captures the issues identified while rebasing branch `work` and resolving merge conflicts.
+
+## Issue 1: Dependency Verification Script Drift During Rebase
+
+**Summary:**
+Conflicting edits changed verification behavior in multiple pipeline helper scripts, creating uncertainty about the expected validation order.
+
+### Sub-issue 1.1: Inconsistent command sequencing
+- **Observation:** One side executed lint checks before environment verification; the other side did the reverse.
+- **Resolution:** Normalize to `verify_environment` before lint to fail fast on missing tooling.
+- **Status:** Closed.
+
+### Sub-issue 1.2: Divergent error messaging
+- **Observation:** Conflict markers showed two distinct failure messages for missing dependencies.
+- **Resolution:** Consolidated to one actionable message with setup guidance.
+- **Status:** Closed.
+
+### Issue comments
+1. **Maintainer comment:** Rebase resolution should prioritize deterministic CI behavior over stylistic differences.
+2. **Reviewer comment:** Added follow-up task to keep command ordering consistent across local and CI runners.
+
+---
+
+## Issue 2: Documentation Regression in Rebased Changelog Content
+
+**Summary:**
+Rebase introduced overlapping changelog updates where one side omitted context for the test-results addition.
+
+### Sub-issue 2.1: Missing rationale in changelog entry
+- **Observation:** Entry existed but lacked reason for adding test report artifacts.
+- **Resolution:** Expanded description to explain auditability and verification intent.
+- **Status:** Closed.
+
+### Sub-issue 2.2: Duplicate bullet formatting styles
+- **Observation:** Conflicting markdown list styles (`-` vs `*`) appeared in adjacent sections.
+- **Resolution:** Standardized to hyphen bullets for consistency in repository markdown files.
+- **Status:** Closed.
+
+### Issue comments
+1. **Maintainer comment:** Documentation conflicts are low risk but still require traceable rationale.
+2. **Reviewer comment:** Keep future changelog edits in one section per topic to reduce rebase friction.


### PR DESCRIPTION
### Motivation
- Capture and preserve the outcomes of a recent rebase on branch `work` where merge conflicts affected CI helper scripts and changelog content. 
- Provide traceable rationale and follow-up notes so future rebases are less error-prone and reviewers can see the chosen resolutions.

### Description
- Add `docs/rebase-conflict-issue-log.md` which records two top-level issues observed during the rebase and four sub-issues with their resolutions. 
- The file documents a dependency verification script drift (command ordering and error messaging) and a documentation/changelog regression (missing rationale and inconsistent bullet style). 
- Include maintainer and reviewer comments for each issue to capture follow-up actions and context; this change is documentation-only and does not modify runtime code paths.

### Testing
- No automated tests were required for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992a20c5c688328ba19f38ea6e069ae)