### PR TITLE
Add Dockerized real-time DPI pipeline with Scapy, Kafka, RedisTimeSeries, and Grafana

### DIFF
--- a/docker/dpi/README.md
+++ b/docker/dpi/README.md
@@ -1,0 +1,93 @@
+# Real-Time Docker DPI Pipeline (Scapy + Kafka + RedisTimeSeries + Grafana)
+
+This stack builds a high-throughput, real-time deep packet inspection (DPI) pipeline:
+
+1. **Scapy capture service** sniffs packets from a host interface.
+2. Packets are serialized and pushed into **Kafka** (`raw.packets` topic).
+3. A **flow processor** consumes Kafka in batches, computes flow-level metrics, and writes counters to **Redis TimeSeries**.
+4. **Grafana** visualizes global throughput, packet rate, protocol trends, and top talkers.
+
+## Architecture
+
+```text
+[Host NIC / any iface]
+        |
+        v
+  packet-capture (Scapy)
+        |
+        v
+      Kafka topic: raw.packets (12 partitions)
+        |
+        v
+    flow-processor (batch + aggregation)
+        |
+        v
+ Redis Stack (RedisTimeSeries + sorted sets + hashes)
+        |
+        v
+      Grafana dashboard (auto provisioned)
+```
+
+## Start the pipeline
+
+```bash
+cd docker/dpi
+docker compose up -d --build
+```
+
+Open Grafana:
+
+- URL: `http://localhost:3000`
+- User: `admin`
+- Password: `admin`
+- Dashboard: **DPI Real-Time Flow Metrics** (folder: `DPI`)
+
+## Optional high-throughput traffic generator
+
+A synthetic UDP generator is included under a profile so the stack can be stress-tested quickly.
+
+```bash
+docker compose --profile load-test up -d traffic-generator
+```
+
+Tune generated load via env vars:
+
+- `RATE_PER_SECOND` (default `5000`)
+- `PAYLOAD_SIZE` (default `1300`)
+
+## Stored metrics
+
+### Global series
+
+- `ts:global:bps` (bytes/sec)
+- `ts:global:pps` (packets/sec)
+
+### Per-protocol series
+
+- `ts:protocol:<PROTO>:bps`
+- `ts:protocol:<PROTO>:pps`
+
+### Per-flow series
+
+- `ts:flow:<FLOW_ID>:bps`
+- `ts:flow:<FLOW_ID>:pps`
+
+Flow metadata and rollups:
+
+- `flow:<FLOW_ID>:meta` hash (5-tuple metadata + cumulative byte/packet totals)
+- `flows:top:bytes` sorted set (top flows by total bytes)
+
+## High-throughput implementation details
+
+- Kafka producer batching (`linger.ms`, `batch_size`, compression).
+- Kafka topic configured with **12 partitions** for parallelism.
+- Consumer polls in large batches (`MAX_POLL_RECORDS=10000`).
+- In-memory per-second aggregation before Redis writes.
+- Redis writes are pipelined and use `TS.INCRBY` for low-overhead append/update semantics.
+- Time series are created lazily with labels and `DUPLICATE_POLICY SUM`.
+
+## Notes
+
+- `packet-capture` runs with `network_mode: host` to sniff host-visible traffic on Linux.
+- Requires Docker Engine with access to host networking + packet capture capabilities.
+- To capture only specific traffic classes, adjust `BPF_FILTER`.

--- a/docker/dpi/capture/Dockerfile
+++ b/docker/dpi/capture/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libpcap0.8 tcpdump \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY producer.py .
+
+CMD ["python", "producer.py"]

--- a/docker/dpi/capture/producer.py
+++ b/docker/dpi/capture/producer.py
@@ -1,0 +1,134 @@
+import json
+import os
+import signal
+import threading
+import time
+from hashlib import blake2b
+from typing import Any, Dict, Optional
+
+from kafka import KafkaProducer
+from scapy.all import IP, IPv6, TCP, UDP, ICMP, ICMPv6EchoRequest, Raw, sniff
+
+BOOTSTRAP_SERVERS = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "kafka:9092")
+TOPIC = os.getenv("KAFKA_TOPIC", "raw.packets")
+INTERFACE = os.getenv("CAPTURE_INTERFACE", "any")
+BPF_FILTER = os.getenv("BPF_FILTER", "ip or ip6")
+BATCH_SIZE = int(os.getenv("KAFKA_BATCH_SIZE", "131072"))
+LINGER_MS = int(os.getenv("KAFKA_LINGER_MS", "5"))
+COMPRESSION = os.getenv("KAFKA_COMPRESSION", "lz4")
+
+RUNNING = True
+
+
+def normalize_transport(packet: Any) -> tuple[int, int, str]:
+    if TCP in packet:
+        layer = packet[TCP]
+        return int(layer.sport), int(layer.dport), "TCP"
+    if UDP in packet:
+        layer = packet[UDP]
+        return int(layer.sport), int(layer.dport), "UDP"
+    if ICMP in packet or ICMPv6EchoRequest in packet:
+        return 0, 0, "ICMP"
+    return 0, 0, "OTHER"
+
+
+def packet_to_record(packet: Any) -> Optional[Dict[str, Any]]:
+    ip_layer = None
+    version = 0
+    if IP in packet:
+        ip_layer = packet[IP]
+        version = 4
+    elif IPv6 in packet:
+        ip_layer = packet[IPv6]
+        version = 6
+
+    if ip_layer is None:
+        return None
+
+    src = str(ip_layer.src)
+    dst = str(ip_layer.dst)
+    sport, dport, transport = normalize_transport(packet)
+    proto = transport if transport != "OTHER" else str(getattr(ip_layer, "proto", getattr(ip_layer, "nh", "UNK")))
+    length = int(len(packet))
+    flow_key = f"{src}|{dst}|{sport}|{dport}|{proto}|{version}"
+    flow_id = blake2b(flow_key.encode("utf-8"), digest_size=12).hexdigest()
+
+    return {
+        "ts_ns": time.time_ns(),
+        "flow_id": flow_id,
+        "src_ip": src,
+        "dst_ip": dst,
+        "src_port": sport,
+        "dst_port": dport,
+        "protocol": proto,
+        "ip_version": version,
+        "packet_bytes": length,
+        "payload_bytes": len(packet[Raw].load) if Raw in packet else 0,
+        "ttl": int(getattr(ip_layer, "ttl", getattr(ip_layer, "hlim", 0))),
+    }
+
+
+def on_send_error(exc: BaseException) -> None:
+    print(f"[capture] kafka send error: {exc}", flush=True)
+
+
+def packet_handler(packet: Any, producer: KafkaProducer) -> None:
+    record = packet_to_record(packet)
+    if not record:
+        return
+
+    future = producer.send(TOPIC, value=record)
+    future.add_errback(on_send_error)
+
+
+def stop_signal_handler(signum: int, _frame: Any) -> None:
+    global RUNNING
+    RUNNING = False
+    print(f"[capture] received signal {signum}, stopping capture loop...", flush=True)
+
+
+def capture_loop(producer: KafkaProducer) -> None:
+    while RUNNING:
+        sniff(
+            iface=INTERFACE,
+            filter=BPF_FILTER,
+            store=False,
+            prn=lambda pkt: packet_handler(pkt, producer),
+            timeout=1,
+        )
+
+
+def main() -> None:
+    signal.signal(signal.SIGINT, stop_signal_handler)
+    signal.signal(signal.SIGTERM, stop_signal_handler)
+
+    producer = KafkaProducer(
+        bootstrap_servers=BOOTSTRAP_SERVERS,
+        value_serializer=lambda v: json.dumps(v, separators=(",", ":")).encode("utf-8"),
+        acks=1,
+        linger_ms=LINGER_MS,
+        batch_size=BATCH_SIZE,
+        compression_type=COMPRESSION,
+        max_in_flight_requests_per_connection=5,
+        retries=5,
+    )
+
+    print(
+        f"[capture] starting scapy on iface={INTERFACE}, filter='{BPF_FILTER}', topic={TOPIC}, kafka={BOOTSTRAP_SERVERS}",
+        flush=True,
+    )
+
+    thread = threading.Thread(target=capture_loop, args=(producer,), daemon=True)
+    thread.start()
+
+    try:
+        while RUNNING:
+            time.sleep(1)
+    finally:
+        producer.flush(timeout=10)
+        producer.close(timeout=10)
+        print("[capture] producer closed", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/dpi/capture/requirements.txt
+++ b/docker/dpi/capture/requirements.txt
@@ -1,0 +1,2 @@
+scapy==2.5.0
+kafka-python==2.0.2

--- a/docker/dpi/docker-compose.yml
+++ b/docker/dpi/docker-compose.yml
@@ -1,0 +1,139 @@
+services:
+  kafka:
+    image: bitnami/kafka:3.7
+    container_name: dpi-kafka
+    ports:
+      - "9092:9092"
+    environment:
+      - KAFKA_CFG_NODE_ID=1
+      - KAFKA_CFG_PROCESS_ROLES=broker,controller
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@kafka:9093
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - KAFKA_CFG_NUM_PARTITIONS=12
+      - KAFKA_CFG_DEFAULT_REPLICATION_FACTOR=1
+      - KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR=1
+      - ALLOW_PLAINTEXT_LISTENER=yes
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server localhost:9092 --list >/dev/null 2>&1"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 25s
+    networks:
+      - dpi
+
+  redis:
+    image: redis/redis-stack-server:7.2.0-v16
+    container_name: dpi-redis
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "PING"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - dpi
+
+  packet-capture:
+    build:
+      context: ./capture
+    container_name: dpi-capture
+    network_mode: host
+    depends_on:
+      kafka:
+        condition: service_healthy
+    environment:
+      - KAFKA_BOOTSTRAP_SERVERS=127.0.0.1:9092
+      - KAFKA_TOPIC=raw.packets
+      - CAPTURE_INTERFACE=any
+      - BPF_FILTER=ip or ip6
+      - KAFKA_BATCH_SIZE=131072
+      - KAFKA_LINGER_MS=5
+      - KAFKA_COMPRESSION=lz4
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    privileged: true
+    restart: unless-stopped
+
+  flow-processor:
+    build:
+      context: ./processor
+    container_name: dpi-flow-processor
+    depends_on:
+      kafka:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+      - KAFKA_TOPIC=raw.packets
+      - KAFKA_GROUP_ID=flow-metrics-v1
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - FLUSH_INTERVAL_SECONDS=1
+      - MAX_POLL_RECORDS=10000
+      - RETENTION_MS=86400000
+    restart: unless-stopped
+    networks:
+      - dpi
+
+  traffic-generator:
+    image: python:3.11-slim
+    container_name: dpi-traffic-generator
+    command:
+      - python
+      - -c
+      - |
+        import os, random, socket, time
+        target_host = os.getenv("TARGET_HOST", "kafka")
+        target_port = int(os.getenv("TARGET_PORT", "9092"))
+        payload_size = int(os.getenv("PAYLOAD_SIZE", "1400"))
+        rate = max(int(os.getenv("RATE_PER_SECOND", "3000")), 1)
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        payload = random.randbytes(payload_size)
+        interval = 1.0 / rate
+        while True:
+            sock.sendto(payload, (target_host, target_port))
+            time.sleep(interval)
+    environment:
+      - TARGET_HOST=kafka
+      - TARGET_PORT=9092
+      - PAYLOAD_SIZE=1300
+      - RATE_PER_SECOND=5000
+    networks:
+      - dpi
+    profiles: ["load-test"]
+
+  grafana:
+    image: grafana/grafana:11.1.4
+    container_name: dpi-grafana
+    depends_on:
+      redis:
+        condition: service_healthy
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_INSTALL_PLUGINS=redis-datasource
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
+      - GF_AUTH_DISABLE_LOGIN_FORM=false
+    volumes:
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
+    networks:
+      - dpi
+
+networks:
+  dpi:
+    driver: bridge

--- a/docker/dpi/grafana/dashboards/dpi-overview.json
+++ b/docker/dpi/grafana/dashboards/dpi-overview.json
@@ -1,0 +1,94 @@
+{
+  "id": null,
+  "uid": "dpi-overview",
+  "title": "DPI Real-Time Flow Metrics",
+  "tags": ["dpi", "kafka", "redis"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "5s",
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Global Throughput (bytes/sec)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "redis-datasource",
+        "uid": "${DS_REDIS-TIMESERIES}"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "query": "TS.RANGE ts:global:bps - + AGGREGATION sum 1000",
+          "type": "timeserie"
+        }
+      ],
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 0}
+    },
+    {
+      "id": 2,
+      "title": "Global Packet Rate (packets/sec)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "redis-datasource",
+        "uid": "${DS_REDIS-TIMESERIES}"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "query": "TS.RANGE ts:global:pps - + AGGREGATION sum 1000",
+          "type": "timeserie"
+        }
+      ],
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 0}
+    },
+    {
+      "id": 3,
+      "title": "Top Flows by Bytes",
+      "type": "table",
+      "datasource": {
+        "type": "redis-datasource",
+        "uid": "${DS_REDIS-TIMESERIES}"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "query": "ZREVRANGE flows:top:bytes 0 20 WITHSCORES",
+          "type": "table"
+        }
+      ],
+      "gridPos": {"h": 10, "w": 12, "x": 0, "y": 9}
+    },
+    {
+      "id": 4,
+      "title": "Protocol Throughput",
+      "type": "timeseries",
+      "datasource": {
+        "type": "redis-datasource",
+        "uid": "${DS_REDIS-TIMESERIES}"
+      },
+      "targets": [
+        {
+          "refId": "TCP",
+          "query": "TS.RANGE ts:protocol:TCP:bps - + AGGREGATION sum 1000",
+          "type": "timeserie"
+        },
+        {
+          "refId": "UDP",
+          "query": "TS.RANGE ts:protocol:UDP:bps - + AGGREGATION sum 1000",
+          "type": "timeserie"
+        },
+        {
+          "refId": "ICMP",
+          "query": "TS.RANGE ts:protocol:ICMP:bps - + AGGREGATION sum 1000",
+          "type": "timeserie"
+        }
+      ],
+      "gridPos": {"h": 10, "w": 12, "x": 12, "y": 9}
+    }
+  ]
+}

--- a/docker/dpi/grafana/provisioning/dashboards/dashboard.yml
+++ b/docker/dpi/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: DPI Dashboards
+    orgId: 1
+    folder: DPI
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/docker/dpi/grafana/provisioning/datasources/datasource.yml
+++ b/docker/dpi/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Redis-TimeSeries
+    type: redis-datasource
+    access: proxy
+    url: redis:6379
+    isDefault: true
+    jsonData:
+      client: standalone
+      poolSize: 8
+      timeout: 10

--- a/docker/dpi/processor/Dockerfile
+++ b/docker/dpi/processor/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY consumer.py .
+
+CMD ["python", "consumer.py"]

--- a/docker/dpi/processor/consumer.py
+++ b/docker/dpi/processor/consumer.py
@@ -1,0 +1,172 @@
+import json
+import os
+import signal
+import time
+from collections import defaultdict
+from typing import Dict, Tuple
+
+import redis
+from kafka import KafkaConsumer
+from redis.exceptions import ResponseError
+
+BOOTSTRAP_SERVERS = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "kafka:9092")
+TOPIC = os.getenv("KAFKA_TOPIC", "raw.packets")
+GROUP_ID = os.getenv("KAFKA_GROUP_ID", "flow-metrics-v1")
+REDIS_HOST = os.getenv("REDIS_HOST", "redis")
+REDIS_PORT = int(os.getenv("REDIS_PORT", "6379"))
+FLUSH_INTERVAL_SECONDS = float(os.getenv("FLUSH_INTERVAL_SECONDS", "1"))
+MAX_POLL_RECORDS = int(os.getenv("MAX_POLL_RECORDS", "10000"))
+RETENTION_MS = int(os.getenv("RETENTION_MS", "86400000"))
+
+RUNNING = True
+SERIES_CACHE = set()
+
+
+def ensure_series(rdb: redis.Redis, key: str, labels: Dict[str, str]) -> None:
+    if key in SERIES_CACHE:
+        return
+    cmd = ["TS.CREATE", key, "RETENTION", RETENTION_MS, "DUPLICATE_POLICY", "SUM", "LABELS"]
+    for label_key, label_value in labels.items():
+        cmd.extend([label_key, label_value])
+    try:
+        rdb.execute_command(*cmd)
+    except ResponseError as exc:
+        if "already exists" not in str(exc).lower():
+            raise
+    SERIES_CACHE.add(key)
+
+
+def safe_flow_metadata(value: Dict[str, object]) -> Dict[str, str]:
+    return {
+        "src_ip": str(value.get("src_ip", "")),
+        "dst_ip": str(value.get("dst_ip", "")),
+        "src_port": str(value.get("src_port", "0")),
+        "dst_port": str(value.get("dst_port", "0")),
+        "protocol": str(value.get("protocol", "UNKNOWN")),
+        "ip_version": str(value.get("ip_version", "0")),
+    }
+
+
+def flush_aggregates(
+    rdb: redis.Redis,
+    flow_aggregate: Dict[str, Dict[str, int]],
+    flow_meta: Dict[str, Dict[str, str]],
+    protocol_aggregate: Dict[str, Dict[str, int]],
+) -> None:
+    if not flow_aggregate and not protocol_aggregate:
+        return
+
+    timestamp_ms = int(time.time() * 1000)
+    pipe = rdb.pipeline(transaction=False)
+
+    global_packets = 0
+    global_bytes = 0
+
+    for flow_id, metrics in flow_aggregate.items():
+        packets = metrics["packets"]
+        bytes_count = metrics["bytes"]
+        global_packets += packets
+        global_bytes += bytes_count
+
+        metadata = flow_meta[flow_id]
+        flow_hash_key = f"flow:{flow_id}:meta"
+        pipe.hset(flow_hash_key, mapping=metadata)
+        pipe.hincrby(flow_hash_key, "total_packets", packets)
+        pipe.hincrby(flow_hash_key, "total_bytes", bytes_count)
+        pipe.expire(flow_hash_key, max(int(RETENTION_MS / 1000), 60))
+
+        pps_key = f"ts:flow:{flow_id}:pps"
+        bps_key = f"ts:flow:{flow_id}:bps"
+        ensure_series(rdb, pps_key, {"scope": "flow", "flow_id": flow_id, **metadata, "metric": "pps"})
+        ensure_series(rdb, bps_key, {"scope": "flow", "flow_id": flow_id, **metadata, "metric": "bps"})
+
+        pipe.execute_command("TS.INCRBY", pps_key, packets, "TIMESTAMP", timestamp_ms)
+        pipe.execute_command("TS.INCRBY", bps_key, bytes_count, "TIMESTAMP", timestamp_ms)
+        pipe.zincrby("flows:top:bytes", bytes_count, flow_id)
+
+    for protocol, metrics in protocol_aggregate.items():
+        proto_pps_key = f"ts:protocol:{protocol}:pps"
+        proto_bps_key = f"ts:protocol:{protocol}:bps"
+        ensure_series(rdb, proto_pps_key, {"scope": "protocol", "protocol": protocol, "metric": "pps"})
+        ensure_series(rdb, proto_bps_key, {"scope": "protocol", "protocol": protocol, "metric": "bps"})
+
+        pipe.execute_command("TS.INCRBY", proto_pps_key, metrics["packets"], "TIMESTAMP", timestamp_ms)
+        pipe.execute_command("TS.INCRBY", proto_bps_key, metrics["bytes"], "TIMESTAMP", timestamp_ms)
+
+    ensure_series(rdb, "ts:global:pps", {"scope": "global", "metric": "pps"})
+    ensure_series(rdb, "ts:global:bps", {"scope": "global", "metric": "bps"})
+    pipe.execute_command("TS.INCRBY", "ts:global:pps", global_packets, "TIMESTAMP", timestamp_ms)
+    pipe.execute_command("TS.INCRBY", "ts:global:bps", global_bytes, "TIMESTAMP", timestamp_ms)
+
+    pipe.execute()
+
+
+def stop_signal_handler(signum: int, _frame: object) -> None:
+    global RUNNING
+    RUNNING = False
+    print(f"[processor] received signal {signum}, draining buffer...", flush=True)
+
+
+def main() -> None:
+    signal.signal(signal.SIGINT, stop_signal_handler)
+    signal.signal(signal.SIGTERM, stop_signal_handler)
+
+    rdb = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=False)
+    consumer = KafkaConsumer(
+        TOPIC,
+        bootstrap_servers=BOOTSTRAP_SERVERS,
+        group_id=GROUP_ID,
+        enable_auto_commit=False,
+        auto_offset_reset="latest",
+        value_deserializer=lambda v: json.loads(v.decode("utf-8")),
+        max_poll_records=MAX_POLL_RECORDS,
+        consumer_timeout_ms=1000,
+        fetch_max_bytes=52428800,
+        max_partition_fetch_bytes=10485760,
+    )
+
+    print(
+        f"[processor] consuming topic={TOPIC} kafka={BOOTSTRAP_SERVERS}, redis={REDIS_HOST}:{REDIS_PORT}",
+        flush=True,
+    )
+
+    flow_aggregate: Dict[str, Dict[str, int]] = defaultdict(lambda: {"packets": 0, "bytes": 0})
+    flow_meta: Dict[str, Dict[str, str]] = {}
+    protocol_aggregate: Dict[str, Dict[str, int]] = defaultdict(lambda: {"packets": 0, "bytes": 0})
+
+    next_flush = time.time() + FLUSH_INTERVAL_SECONDS
+
+    while RUNNING:
+        records_pack = consumer.poll(timeout_ms=250, max_records=MAX_POLL_RECORDS)
+        for _topic_partition, records in records_pack.items():
+            for record in records:
+                packet = record.value
+                flow_id = str(packet.get("flow_id", "unknown"))
+                packet_bytes = int(packet.get("packet_bytes", 0))
+                protocol = str(packet.get("protocol", "UNKNOWN")).upper()
+
+                flow_aggregate[flow_id]["packets"] += 1
+                flow_aggregate[flow_id]["bytes"] += packet_bytes
+                flow_meta.setdefault(flow_id, safe_flow_metadata(packet))
+
+                protocol_aggregate[protocol]["packets"] += 1
+                protocol_aggregate[protocol]["bytes"] += packet_bytes
+
+        now = time.time()
+        if now >= next_flush:
+            flush_aggregates(rdb, flow_aggregate, flow_meta, protocol_aggregate)
+            if records_pack:
+                consumer.commit()
+            flow_aggregate.clear()
+            flow_meta.clear()
+            protocol_aggregate.clear()
+            next_flush = now + FLUSH_INTERVAL_SECONDS
+
+    flush_aggregates(rdb, flow_aggregate, flow_meta, protocol_aggregate)
+    if flow_aggregate:
+        consumer.commit()
+    consumer.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/dpi/processor/requirements.txt
+++ b/docker/dpi/processor/requirements.txt
@@ -1,0 +1,2 @@
+kafka-python==2.0.2
+redis==5.0.7


### PR DESCRIPTION
### Motivation
- Provide a self-contained, Docker Compose stack to capture network packets, compute real-time flow metrics, and visualize them for high-throughput DPI use cases.
- Use Scapy for flexible packet capture, Kafka for scalable ingestion and partitioning, Redis TimeSeries for low-latency time-series counters, and Grafana for live dashboards.
- Include a synthetic traffic generator profile to enable stress-testing and validation of the pipeline under load.

### Description
- Add a new Compose stack at `docker/dpi/docker-compose.yml` that brings up `kafka`, `redis` (Redis Stack), `packet-capture` (Scapy producer), `flow-processor` (Kafka consumer), `grafana` (auto-provisioned), and an optional `traffic-generator` profile for load testing.
- Implement a Scapy-based capture producer in `docker/dpi/capture/producer.py` that normalizes packets to a 5-tuple, computes a `flow_id`, and sends JSON records to Kafka with batching and compression tuned for throughput, plus a `Dockerfile` and `requirements.txt` for the service.
- Implement a flow processor in `docker/dpi/processor/consumer.py` that polls Kafka in large batches, aggregates per-flow and per-protocol counters per flush interval, writes `TS.INCRBY` updates to Redis TimeSeries, maintains per-flow metadata hashes and a top-flows sorted set, and includes a `Dockerfile` and `requirements.txt` for the service.
- Add Grafana provisioning files and a prebuilt dashboard under `docker/dpi/grafana/` and documentation `docker/dpi/README.md` describing architecture, start instructions, metric keys, and load-test usage.

### Testing
- Successfully byte-compiled the Python modules with `python -m py_compile docker/dpi/capture/producer.py docker/dpi/processor/consumer.py` (succeeded).
- Attempted Docker Compose validation with `docker compose -f docker/dpi/docker-compose.yml config`, which could not run in this environment because the Docker CLI was not available (failed due to missing `docker`).
- Attempted to parse Compose/Grafana YAML with a short Python script, which failed here because `PyYAML` is not installed in the execution environment (failed due to `ModuleNotFoundError`).
- Attempted a Playwright screenshot of Grafana at `http://127.0.0.1:3000`, which returned `ERR_EMPTY_RESPONSE` because the services were not running in this environment (failed to reach Grafana).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699372dc0d0083238618e363c6cd67fd)