### PR TITLE
Add monitoring stack compose with Prometheus scrape targets and Grafana datasource

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,109 +1,104 @@
 services:
-  nginx:
-    build:
-      context: .
-      dockerfile: docker/nginx/Dockerfile
-    image: iato/nginx-edge:local
-    container_name: iato-nginx
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.6.1
+    container_name: zookeeper
+    restart: unless-stopped
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+    networks:
+      - monitoring
+
+  kafka:
+    image: confluentinc/cp-kafka:7.6.1
+    container_name: kafka
+    restart: unless-stopped
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_JMX_PORT: 9999
+      KAFKA_JMX_HOSTNAME: kafka
+    ports:
+      - "9092:9092"
+      - "9999:9999"
+    networks:
+      - monitoring
+
+  redis:
+    image: redis:7.2-alpine
+    container_name: redis
     restart: unless-stopped
     ports:
-      - "${NGINX_PORT:-8080}:80"
-    depends_on:
-      apache:
-        condition: service_healthy
-    healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost/healthz"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 10s
+      - "6379:6379"
     networks:
-      - web
+      - monitoring
 
-  apache:
-    build:
-      context: .
-      dockerfile: docker/apache/Dockerfile
-    image: iato/apache-proxy:local
-    container_name: iato-apache
+  kafka_exporter:
+    image: danielqsj/kafka-exporter:v1.7.0
+    container_name: kafka_exporter
     restart: unless-stopped
-    expose:
-      - "8080"
     depends_on:
-      drupal:
-        condition: service_healthy
-    healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://localhost:8080/healthz"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 15s
+      - kafka
+    command:
+      - --kafka.server=kafka:9092
+    ports:
+      - "9308:9308"
     networks:
-      - web
+      - monitoring
 
-  drupal:
-    build:
-      context: .
-      dockerfile: docker/drupal/Dockerfile
-    image: iato/drupal-s3:local
-    container_name: iato-drupal
+  redis_exporter:
+    image: oliver006/redis_exporter:v1.62.0
+    container_name: redis_exporter
     restart: unless-stopped
-    expose:
-      - "80"
     depends_on:
-      db:
-        condition: service_healthy
+      - redis
     environment:
-      DRUPAL_DB_HOST: ${DRUPAL_DB_HOST:-db}
-      DRUPAL_DB_NAME: ${DRUPAL_DB_NAME:-drupal}
-      DRUPAL_DB_USER: ${DRUPAL_DB_USER:-drupal}
-      DRUPAL_DB_PASSWORD: ${DRUPAL_DB_PASSWORD:-drupal-pass}
-      AWS_REGION: ${AWS_REGION:-us-east-1}
-      S3_BUCKET: ${S3_BUCKET:-}
-      S3_PREFIX: ${S3_PREFIX:-sites/default/files}
-      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
-      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
-    volumes:
-      - drupal_files:/var/www/html/sites/default/files
-    cap_add:
-      - SYS_ADMIN
-    devices:
-      - /dev/fuse:/dev/fuse
-    security_opt:
-      - apparmor:unconfined
-    healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://localhost/"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 30s
+      REDIS_ADDR: redis://redis:6379
+    ports:
+      - "9121:9121"
     networks:
-      - web
+      - monitoring
 
-  db:
-    image: mariadb:11
-    container_name: iato-db
+  prometheus:
+    image: prom/prometheus:v2.53.1
+    container_name: prometheus
     restart: unless-stopped
-    environment:
-      MARIADB_DATABASE: ${DRUPAL_DB_NAME:-drupal}
-      MARIADB_USER: ${DRUPAL_DB_USER:-drupal}
-      MARIADB_PASSWORD: ${DRUPAL_DB_PASSWORD:-drupal-pass}
-      MARIADB_ROOT_PASSWORD: ${MARIADB_ROOT_PASSWORD:-root-pass}
     volumes:
-      - db_data:/var/lib/mysql
-    healthcheck:
-      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
-      interval: 20s
-      timeout: 10s
-      retries: 10
-      start_period: 30s
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    depends_on:
+      - kafka_exporter
+      - redis_exporter
     networks:
-      - web
+      - monitoring
+
+  grafana:
+    image: grafana/grafana:11.1.0
+    container_name: grafana
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+    networks:
+      - monitoring
 
 volumes:
-  drupal_files:
-  db_data:
+  grafana_data:
 
 networks:
-  web:
+  monitoring:
     driver: bridge

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: kafka_exporter
+    static_configs:
+      - targets:
+          - kafka_exporter:9308
+
+  - job_name: redis_exporter
+    static_configs:
+      - targets:
+          - redis_exporter:9121


### PR DESCRIPTION
### Motivation
- Provide a self-contained monitoring stack (Kafka, Zookeeper, Redis, Prometheus, Grafana, kafka_exporter, redis_exporter) for local deployments and testing.
- Ensure Kafka exposes JMX metrics for JMX-based monitoring and tooling.
- Collect metrics from `kafka_exporter` and `redis_exporter` into Prometheus. 
- Auto-provision Grafana with Prometheus as the default datasource to simplify first-run setup.

### Description
- Replaced the root `docker-compose.yml` with a monitoring-focused compose that defines `zookeeper`, `kafka` (with `KAFKA_JMX_PORT=9999` exposed), `redis`, `kafka_exporter`, `redis_exporter`, `prometheus`, and `grafana` on a single bridge network named `monitoring`.
- Configured `kafka_exporter` to connect to `kafka:9092` and expose metrics on port `9308`, and configured `redis_exporter` to point at `redis:6379` and expose metrics on port `9121`.
- Added `monitoring/prometheus/prometheus.yml` and mounted it into the Prometheus container, with scrape jobs for `kafka_exporter:9308` and `redis_exporter:9121`.
- Added Grafana provisioning file `monitoring/grafana/provisioning/datasources/datasource.yml` to automatically configure Prometheus at `http://prometheus:9090` as the default datasource.

### Testing
- Parsed `docker-compose.yml`, `monitoring/prometheus/prometheus.yml`, and `monitoring/grafana/provisioning/datasources/datasource.yml` using Ruby's `YAML.load_file`, which succeeded for all three files.
- Attempted to validate the compose with `docker compose config`, but the command could not run because Docker is not installed in the environment (`bash: command not found: docker`).
- Attempted to parse YAML with Python, but that run failed due to the environment missing the `yaml` module (`ModuleNotFoundError: No module named 'yaml'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69937a5f4cb88323b8cf3ac07124687c)