### PR TITLE
Add host-visible node-exporter sidecar and Prometheus host-metrics scrape target

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,20 @@ services:
       - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus-data:/prometheus
 
+  node-exporter:
+    image: prom/node-exporter:v1.8.2
+    container_name: node-exporter
+    restart: unless-stopped
+    network_mode: "service:enclave"
+    pid: host
+    depends_on:
+      - enclave
+    command:
+      - --path.rootfs=/host
+      - --path.procfs=/host/proc
+      - --path.sysfs=/host/sys
+    volumes:
+      - /:/host:ro,rslave
   grafana:
     image: grafana/grafana:11.1.0
     container_name: grafana

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -14,6 +14,11 @@ scrape_configs:
       - targets:
           - localhost:9090
 
+  - job_name: host-metrics
+    static_configs:
+      - targets:
+          - localhost:9100
+
   - job_name: enclave-remote-peers
     scheme: http
     static_configs:


### PR DESCRIPTION
### Motivation
- Provide host-level visibility for process and hardware monitoring so Prometheus can collect host metrics for the Auditable Trust audit trail.
- Run the exporter inside the existing enclave network namespace so Prometheus can scrape it via `localhost:9100`.
- Enable the sidecar to inspect host PIDs and host filesystem/proc/sys data required for accurate host metrics.

### Description
- Added a `node-exporter` service to `docker-compose.yml` using `prom/node-exporter:v1.8.2` with `network_mode: "service:enclave"` and `pid: host` to allow host PID visibility.
- Configured the exporter to mount the host root as read-only with `/:/host:ro,rslave` and pass flags `--path.rootfs=/host`, `--path.procfs=/host/proc`, and `--path.sysfs=/host/sys` so it reports host process and system metrics.
- Updated `monitoring/prometheus/prometheus.yml` to add a `host-metrics` scrape job targeting `localhost:9100` so Prometheus will collect the sidecar metrics.
- Ensured the sidecar depends on the `enclave` service so it shares the enclave network namespace for local scraping.

### Testing
- Ran `git diff -- docker-compose.yml monitoring/prometheus/prometheus.yml` to inspect changes and the diff matched the intended edits (succeeded).
- Committed the changes via `git commit` and the commit completed successfully (succeeded).
- Attempted `ENCLAVE_ENROLMENT_KEY=dummy DRUPAL_DB_PASSWORD=dummy MARIADB_ROOT_PASSWORD=dummy GRAFANA_ADMIN_PASSWORD=dummy docker compose config >/tmp/compose.out` to validate compose, but the `docker` CLI is not available in this environment (failed).
- Attempted to `yaml.safe_load` both YAML files with Python to validate syntax, but the `PyYAML` module is not installed in the environment so that automated check could not be performed (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993925caea88323b32e4f33b3f64379)