### PR TITLE
Configure node-exporter sidecar for enclave host monitoring

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,15 +37,18 @@ services:
     container_name: node-exporter
     restart: unless-stopped
     network_mode: "service:enclave"
-    pid: host
+    pid: "host"
     depends_on:
       - enclave
     command:
-      - --path.rootfs=/host
-      - --path.procfs=/host/proc
-      - --path.sysfs=/host/sys
+      - '--path.procfs=/host/proc'
+      - '--path.sysfs=/host/sys'
+      - '--path.rootfs=/rootfs'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
     volumes:
-      - /:/host:ro,rslave
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro,rslave
   grafana:
     image: grafana/grafana:11.1.0
     container_name: grafana

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -14,7 +14,7 @@ scrape_configs:
       - targets:
           - localhost:9090
 
-  - job_name: host-metrics
+  - job_name: host-monitoring
     static_configs:
       - targets:
           - localhost:9100


### PR DESCRIPTION
### Motivation
- Provide an enclave sidecar `node-exporter` that exposes host-level metrics to Prometheus via the shared Enclave network namespace and host PID namespace for auditable visibility.
- Ensure node-exporter reads host kernel and filesystem state from explicit read-only host mounts to avoid exposing unintended paths.

### Description
- Updated the `node-exporter` service in `docker-compose.yml` to use `network_mode: "service:enclave"` and `pid: "host"` so metrics are available at `localhost:9100` within the Enclave namespace.
- Replaced the exporter flags to point at the mapped host paths and added the filesystem mount exclusion regex by setting `command` to include `--path.procfs=/host/proc`, `--path.sysfs=/host/sys`, `--path.rootfs=/rootfs`, and `--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)`.
- Mounted host directories read-only in `docker-compose.yml` as `- /proc:/host/proc:ro`, `- /sys:/host/sys:ro`, and `- /:/rootfs:ro,rslave` to provide the exporter with necessary visibility while limiting write access.
- Renamed the Prometheus scrape job from `host-metrics` to `host-monitoring` in `monitoring/prometheus/prometheus.yml` and kept the target as `localhost:9100` for loopback scraping when sharing the namespace.

### Testing
- Ran YAML parsing with `ruby -e "require 'yaml'; YAML.load_file('docker-compose.yml'); YAML.load_file('monitoring/prometheus/prometheus.yml'); puts 'yaml-parse-ok'"` which succeeded and printed `yaml-parse-ok`.
- Attempted YAML parsing with a Python script using `yaml.safe_load` which failed due to missing `PyYAML` (`ModuleNotFoundError: No module named 'yaml'`).
- Attempted `docker compose -f docker-compose.yml config` to validate the compose file but it failed because `docker` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993947d294083238d1803b64117235c)