### PR TITLE
Expose Grafana on Enclave; add dashboard provisioning and Node Exporter dashboard

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,9 +62,12 @@ services:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?set in .env}
       GF_SERVER_HTTP_PORT: 3000
+    ports:
+      - "3000:3000"
     volumes:
       - grafana-data:/var/lib/grafana
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./monitoring/grafana/dashboards:/etc/grafana/dashboards:ro
 
   db:
     image: mariadb:11.4
@@ -125,12 +128,9 @@ services:
     container_name: nginx
     restart: unless-stopped
     depends_on:
-      - apache
-    ports:
-      - "${NGINX_PORT:-8080}:80"
-    networks:
-      - app_net
-      - enclave_net
+      - enclave
+      - grafana
+    network_mode: "service:enclave"
 
 volumes:
   mariadb-data:

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -22,6 +22,6 @@ server {
     proxy_buffering off;
     proxy_read_timeout 60s;
     proxy_connect_timeout 5s;
-    proxy_pass http://apache:8080;
+    proxy_pass http://127.0.0.1:3000;
   }
 }

--- a/monitoring/grafana/dashboards/node-exporter-full-1860.json
+++ b/monitoring/grafana/dashboards/node-exporter-full-1860.json
@@ -1,0 +1,117 @@
+{
+  "__inputs": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.1.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Node Exporter Full dashboard seed (Grafana.com dashboard ID 1860).",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [
+    {
+      "title": "Grafana Dashboard 1860",
+      "type": "link",
+      "url": "https://grafana.com/grafana/dashboards/1860-node-exporter-full/"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "1 - avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m])) by (instance)",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Usage",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "node-exporter",
+    "prometheus",
+    "1860"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Node Exporter Full",
+  "uid": "node-exporter-full-1860",
+  "version": 1,
+  "weekStart": ""
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboard.yaml
+++ b/monitoring/grafana/provisioning/dashboards/dashboard.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/dashboards


### PR DESCRIPTION
### Motivation
- Make Grafana reachable through the Enclave network namespace and enable dashboard provisioning from the repository. 
- Provide a seeded Node Exporter Full dashboard (Grafana ID 1860) so Grafana starts with a useful Prometheus dashboard. 
- Route incoming HTTP traffic from the Enclave interface to the Grafana web server via the existing nginx reverse proxy.

### Description
- Map Grafana port by adding `ports: - "3000:3000"` and mount `./monitoring/grafana/dashboards` into the container at `/etc/grafana/dashboards` in `docker-compose.yml` for dashboard provisioning via files. 
- Add a Grafana provisioning provider file at `monitoring/grafana/provisioning/dashboards/dashboard.yaml` that points Grafana to `/etc/grafana/dashboards`. 
- Add a local seeded dashboard JSON at `monitoring/grafana/dashboards/node-exporter-full-1860.json` containing a Node Exporter Full dashboard skeleton referring to `${DS_PROMETHEUS}`. 
- Reconfigure `nginx` to run in the Enclave network namespace by setting `network_mode: "service:enclave"` and update `docker/nginx/default.conf` to proxy to `http://127.0.0.1:3000` so nginx forwards Enclave-bound traffic to the Grafana HTTP port.

### Testing
- Attempted remote fetch of the official Grafana.com dashboard (`curl https://grafana.com/api/dashboards/1860/revisions/latest/download`) failed with `403` so the dashboard was seeded locally (automated fetch failed). 
- Running `docker compose config` in this environment failed because the `docker` CLI is not available (automated check failed). 
- YAML parsing of `docker-compose.yml` and `monitoring/grafana/provisioning/dashboards/dashboard.yaml` succeeded using a Ruby YAML load check (automated check succeeded). 
- JSON validation of `monitoring/grafana/dashboards/node-exporter-full-1860.json` via `python -m json.tool` succeeded (automated check succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69939950511c8323b9cef2228c9ed8c1)