### PR TITLE
Add XDP audit program, libbpfgo sidecar, and Enclave compose wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,137 +1,139 @@
-# Auditable Trust Object: Enclave + eBPF/XDP Monitoring Stack
+# Intent-to-Auditable Trust Object: XDP → BPF Maps → Enclave SDN
 
-This repository ships a secure and auditable monitoring architecture that combines:
+This repository now includes a complete, hardware-software co-designed monitoring stack that bridges:
 
-- **Line-rate kernel telemetry** from a CO-RE XDP/eBPF netflow filter (`ebpf/netflow_filter.bpf.c`),
-- **A Go-based enclave sidecar** that reads an eBPF per-CPU flow map and exports Prometheus metrics,
-- **A private overlay network backbone** for observability and dashboard access,
-- **An isolated app plane** (`Nginx -> Drupal -> MariaDB`) on `app_net`.
+- **Layer 1 (XDP hook):** high-speed packet parsing + timing capture in kernel space.
+- **Layer 2 (BPF Maps):** `flow_map` in `BPF_MAP_TYPE_PERCPU_HASH` sized for **1M concurrent flows**.
+- **Layer 3 (Enclave SDN):** Prometheus, Grafana, and sidecar all bound to the Enclave service namespace.
 
-## 1) Architecture
+---
 
-### Software-Verilog Layer (Kernel/NIC path)
+## 1) Components Delivered
 
-- `ebpf/netflow_filter.bpf.c` attaches at the XDP hook and is intended for **`XDP_DRV`** (driver mode) and optionally **`XDP_HW`** where NIC offload is supported.
-- The program parses IPv4 TCP/UDP headers and implements `netflow_filter` by aggregating packet + byte counters per 5-tuple flow.
-- Flow state is stored in `flow_map` using `BPF_MAP_TYPE_PERCPU_HASH` so each CPU updates local counters without cross-core lock contention.
-- The BPF object is built with BTF/CO-RE (`vmlinux.h` generated from `/sys/kernel/btf/vmlinux`) for portability across compatible kernels.
+### XDP kernel module (`ebpf/xdp_audit.c`)
 
-### Bridge Layer (Userspace sidecar)
+- Exposes XDP program section `netflow_filter`.
+- Parses Ethernet/IPv4/TCP/UDP and derives 5-tuple flow keys.
+- Tracks per-flow packet/byte counters and first/last-seen timestamps in:
+  - `flow_map` (`BPF_MAP_TYPE_PERCPU_HASH`, `max_entries=1048576`).
+- Uses `bpf_ktime_get_ns()` for nanosecond packet timing deltas.
+- Emits audit alerts through `events` (`BPF_MAP_TYPE_RINGBUF`) when:
+  - packet-rate spike thresholds are exceeded,
+  - ultra-low inter-packet timing deltas suggest potential side-channel leakage.
 
-- `ebpf/netflow-sidecar/main.go` loads and attaches the XDP program, then polls `flow_map`.
-- The sidecar exports `/metrics` on port `9400` over the enclave vNET namespace.
-- Exported metrics include:
-  - `xdp_netflow_active_flows`
-  - `xdp_netflow_packets_total_snapshot`
-  - `xdp_netflow_bytes_total_snapshot`
-  - `xdp_netflow_flow_packets` (top-N)
-  - `xdp_netflow_flow_bytes` (top-N)
-- Container runs with:
-  - `network_mode: "service:enclave"`
-  - `privileged: true`
-  - host mount for `/sys/kernel/btf`.
+### Go sidecar bridge (`ebpf/netflow-sidecar/main.go`)
 
-### Hybrid Compose Topology
+- Uses **libbpf via `libbpfgo`** to:
+  - load CO-RE object `/opt/netflow/xdp_audit.bpf.o`,
+  - attach `netflow_filter` to the configured NIC.
+- Aggregates per-CPU flow counters from `flow_map` into global snapshots.
+- Publishes Prometheus metrics at `/metrics` (default `:9400`).
+- Subscribes to the ring buffer (`events`) and logs audit messages as:
+  - `Trust Violation reason=...`
 
-- **Enclave service** provides the secure networking backbone and `.enclave` name resolution.
-- **Prometheus + Grafana** run in the enclave network namespace and scrape the XDP sidecar privately.
-- **App stack** (`drupal`, `apache`, `db`) remains isolated on `app_net`.
-- **Gateway Nginx** is attached to the enclave namespace and exposes TLS on host port `443`.
+### Enclave-wrapped compose topology (`docker-compose.yml`)
 
-## 2) Key Files
+- `xdp-auditor`, `prometheus`, and `grafana` run with:
+  - `network_mode: "service:enclave"`.
+- BPF sidecar runs with:
+  - `privileged: true`,
+  - `/sys/fs/bpf` mount,
+  - `/lib/modules` mount,
+  - `/sys/kernel/btf` mount.
+- App plane (`drupal`, `db`, `apache`) remains isolated on `app_net` and does not need awareness of the eBPF monitor.
 
-- `ebpf/netflow_filter.bpf.c`
-- `ebpf/netflow-sidecar/main.go`
-- `ebpf/netflow-sidecar/entrypoint.sh`
-- `ebpf/netflow-sidecar/Dockerfile`
-- `docker-compose.yml`
-- `prometheus.yml`
+---
 
-## 3) WSL2 Quick Start
+## 2) WSL2 Quick Start
 
-1. **Prerequisites**
-
-   - Docker Desktop with WSL2 backend enabled.
-   - Linux kernel with eBPF/XDP support and `/sys/kernel/btf/vmlinux` exposed.
-   - Enclave enrolment key.
-
-2. **Prepare environment**
-
-   ```bash
-   cp .env.example .env
-   ```
-
-   Set at minimum:
-
-   - `ENCLAVE_ENROLMENT_KEY`
-   - `DRUPAL_DB_PASSWORD`
-   - `MARIADB_ROOT_PASSWORD`
-   - `GRAFANA_ADMIN_PASSWORD`
-
-   Optional XDP tuning:
-
-   - `XDP_INTERFACE=eth0`
-   - `XDP_MODE=drv` (`drv`, `hw`, or `skb`)
-   - `NETFLOW_POLL_INTERVAL=10s`
-   - `NETFLOW_TOPK=50`
-
-3. **Create TLS certificate**
-
-   ```bash
-   mkdir -p certs
-   openssl req -x509 -nodes -newkey rsa:2048 -days 365 \
-     -keyout certs/tls.key \
-     -out certs/tls.crt \
-     -subj "/CN=grafana.enclave"
-   ```
-
-4. **Launch stack**
-
-   ```bash
-   docker compose up -d --build
-   ```
-
-## 4) Verification
-
-### A. Verify XDP hook attachment
+1. Copy env template:
 
 ```bash
-docker exec enclave_agent ip link show
+cp .env.example .env
 ```
+
+2. Set required secrets in `.env`:
+
+- `ENCLAVE_ENROLMENT_KEY`
+- `DRUPAL_DB_PASSWORD`
+- `MARIADB_ROOT_PASSWORD`
+- `GRAFANA_ADMIN_PASSWORD`
+
+3. Optional XDP tuning:
 
 ```bash
-docker logs xdp-auditor --tail=50
+XDP_INTERFACE=eth0
+XDP_MODE=drv
+NETFLOW_POLL_INTERVAL=10s
+NETFLOW_TOPK=50
 ```
 
-You should see startup output similar to:
-
-- `netflow_filter attached to eth0 (mode=drv)`
-
-### B. Verify Prometheus metrics path
+4. Build and start:
 
 ```bash
-docker exec enclave_agent wget -qO- http://localhost:9400/metrics | head
+docker compose up -d --build
 ```
+
+---
+
+## 3) Verify the XDP-to-Enclave Pipeline
+
+### A. Confirm XDP program is attached
 
 ```bash
-docker exec enclave_agent wget -qO- http://localhost:9090/-/ready
+docker logs xdp-auditor --tail=100
 ```
 
-### C. Verify enclave dashboard access (Trust Object)
+Expected log includes:
 
-Open these URLs from your browser:
+- `netflow_filter attached via libbpf on <iface>`
 
-- `https://grafana.enclave`
-- `https://drupal.enclave`
+### B. Confirm ringbuf trust-violation stream
 
-Login to Grafana and validate scrape health + XDP series:
+```bash
+docker logs -f xdp-auditor
+```
+
+Look for entries similar to:
+
+- `Trust Violation reason=1 ...`
+- `Trust Violation reason=2 ...`
+
+### C. Confirm Prometheus sees flow metrics
+
+```bash
+docker exec enclave_agent wget -qO- http://localhost:9400/metrics | head -40
+```
+
+Metrics include:
 
 - `xdp_netflow_active_flows`
 - `xdp_netflow_packets_total_snapshot`
 - `xdp_netflow_flow_packets`
 
-## 5) Teardown
+### D. Confirm dashboard endpoints via Enclave virtual IP / name
 
-```bash
-docker compose down -v
-```
+Open in your browser:
+
+- `https://grafana.enclave`
+
+If your Enclave setup assigns a specific virtual IP for Grafana, use:
+
+- `https://<enclave-virtual-ip>:443`
+
+In Grafana, query:
+
+- `xdp_netflow_active_flows`
+- `xdp_netflow_flow_packets`
+- `xdp_netflow_flow_bytes`
+
+for real-time, line-rate flow telemetry and timing audit visibility.
+
+---
+
+## 4) Delivered Files
+
+- `ebpf/xdp_audit.c`
+- `ebpf/netflow-sidecar/main.go`
+- `docker-compose.yml`
+- `README.md`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,8 +35,11 @@ services:
       METRICS_ADDR: 0.0.0.0:9400
       NETFLOW_POLL_INTERVAL: ${NETFLOW_POLL_INTERVAL:-10s}
       NETFLOW_TOPK: ${NETFLOW_TOPK:-50}
+      BPF_OBJECT: /opt/netflow/xdp_audit.bpf.o
     volumes:
       - /sys/kernel/btf:/sys/kernel/btf:ro
+      - /sys/fs/bpf:/sys/fs/bpf
+      - /lib/modules:/lib/modules:ro
 
   node-exporter:
     image: prom/node-exporter:v1.8.2

--- a/ebpf/netflow-sidecar/Dockerfile
+++ b/ebpf/netflow-sidecar/Dockerfile
@@ -1,8 +1,12 @@
 FROM golang:1.22-bookworm AS builder
 WORKDIR /src
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    clang llvm libbpf-dev libelf-dev pkg-config gcc make \
+    && rm -rf /var/lib/apt/lists/*
 COPY netflow-sidecar/go.mod ./go.mod
 COPY netflow-sidecar/main.go ./main.go
-RUN go build -o /out/netflow-sidecar ./main.go
+RUN go mod download
+RUN CGO_ENABLED=1 go build -o /out/netflow-sidecar ./main.go
 
 FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
@@ -16,7 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/netflow
-COPY netflow_filter.bpf.c /opt/netflow/netflow_filter.bpf.c
+COPY xdp_audit.c /opt/netflow/xdp_audit.c
 COPY netflow-sidecar/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 COPY --from=builder /out/netflow-sidecar /usr/local/bin/netflow-sidecar

--- a/ebpf/netflow-sidecar/entrypoint.sh
+++ b/ebpf/netflow-sidecar/entrypoint.sh
@@ -12,7 +12,7 @@ bpftool btf dump file /sys/kernel/btf/vmlinux format c > /opt/netflow/vmlinux.h
 
 clang -O2 -g -target bpf -D__TARGET_ARCH_x86 \
   -I/opt/netflow \
-  -c /opt/netflow/netflow_filter.bpf.c \
-  -o /opt/netflow/netflow_filter.bpf.o
+  -c /opt/netflow/xdp_audit.c \
+  -o /opt/netflow/xdp_audit.bpf.o
 
 exec /usr/local/bin/netflow-sidecar

--- a/ebpf/netflow-sidecar/go.mod
+++ b/ebpf/netflow-sidecar/go.mod
@@ -1,3 +1,5 @@
 module netflow-sidecar
 
 go 1.22
+
+require github.com/aquasecurity/libbpfgo v0.8.0-libbpf-1.5

--- a/ebpf/xdp_audit.c
+++ b/ebpf/xdp_audit.c
@@ -1,17 +1,16 @@
 #include <linux/bpf.h>
 #include <linux/if_ether.h>
 #include <linux/ip.h>
-#include <linux/in.h>
-#include <linux/udp.h>
 #include <linux/tcp.h>
-#include <bpf/bpf_helpers.h>
+#include <linux/udp.h>
 #include <bpf/bpf_endian.h>
+#include <bpf/bpf_helpers.h>
 
 char LICENSE[] SEC("license") = "GPL";
 
-#define TVLA_ABS_T_THRESHOLD 4
-#define TVLA_MIN_SAMPLES 32
-#define EPSILON_NS 1
+#define MAX_FLOWS 1048576
+#define SPIKE_THRESHOLD_PPS 50000
+#define NS_PER_SEC 1000000000ULL
 
 struct flow_key {
     __u32 src_ip;
@@ -19,222 +18,162 @@ struct flow_key {
     __u16 src_port;
     __u16 dst_port;
     __u8 proto;
+    __u8 pad[3];
 };
 
-struct flow_state {
+struct flow_metrics {
+    __u64 packets;
+    __u64 bytes;
     __u64 last_seen_ns;
+    __u64 first_seen_ns;
 };
 
-struct tvla_state {
-    __u64 sample_count;
-    __u64 mean;
-    __u64 m2;
+struct spike_state {
+    __u64 window_start_ns;
+    __u64 pkt_count;
 };
 
 struct audit_event {
     __u64 ts_ns;
+    __u64 window_packets;
+    __u64 pkt_delta_ns;
     __u32 src_ip;
     __u32 dst_ip;
     __u16 src_port;
     __u16 dst_port;
     __u8 proto;
-    __u16 pkt_len;
-    __u64 delta_ns;
-    __u64 mean_ns;
-    __u64 variance_ns;
-    __u32 tvla_tscore;
-    __u8 leak_flag;
+    __u8 reason;
 };
 
 struct {
-    __uint(type, BPF_MAP_TYPE_HASH);
-    __uint(max_entries, 131072);
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+    __uint(max_entries, MAX_FLOWS);
     __type(key, struct flow_key);
-    __type(value, struct flow_state);
-} flow_tracker SEC(".maps");
+    __type(value, struct flow_metrics);
+} flow_map SEC(".maps");
 
 struct {
-    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
     __uint(max_entries, 1);
     __type(key, __u32);
-    __type(value, struct tvla_state);
-} timing_stats SEC(".maps");
+    __type(value, struct spike_state);
+} spike_guard SEC(".maps");
 
 struct {
-    __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
-} audit_events SEC(".maps");
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 1 << 24);
+} events SEC(".maps");
 
-static __always_inline int parse_l4(void *data, void *data_end, struct flow_key *key, __u16 *pkt_len)
+static __always_inline int parse_flow(void *data, void *data_end, struct flow_key *id)
 {
     struct ethhdr *eth = data;
-    if ((void *)(eth + 1) > data_end) {
+    if ((void *)(eth + 1) > data_end)
         return -1;
-    }
 
-    if (eth->h_proto != bpf_htons(ETH_P_IP)) {
+    if (eth->h_proto != bpf_htons(ETH_P_IP))
         return -1;
-    }
 
-    struct iphdr *ip = (void *)(eth + 1);
-    if ((void *)(ip + 1) > data_end) {
+    struct iphdr *iph = (void *)(eth + 1);
+    if ((void *)(iph + 1) > data_end)
         return -1;
-    }
 
-    if (ip->ihl < 5) {
+    if (iph->ihl < 5)
         return -1;
-    }
 
-    void *l4 = (void *)ip + (ip->ihl * 4);
-    if (l4 > data_end) {
+    void *l4 = (void *)iph + (iph->ihl * 4);
+    if (l4 > data_end)
         return -1;
-    }
 
-    key->src_ip = ip->saddr;
-    key->dst_ip = ip->daddr;
-    key->proto = ip->protocol;
-    key->src_port = 0;
-    key->dst_port = 0;
+    id->src_ip = iph->saddr;
+    id->dst_ip = iph->daddr;
+    id->proto = iph->protocol;
+    id->src_port = 0;
+    id->dst_port = 0;
 
-    if (ip->protocol == IPPROTO_TCP) {
-        struct tcphdr *tcp = l4;
-        if ((void *)(tcp + 1) > data_end) {
+    if (iph->protocol == IPPROTO_TCP) {
+        struct tcphdr *th = l4;
+        if ((void *)(th + 1) > data_end)
             return -1;
-        }
-        key->src_port = tcp->source;
-        key->dst_port = tcp->dest;
-    } else if (ip->protocol == IPPROTO_UDP) {
-        struct udphdr *udp = l4;
-        if ((void *)(udp + 1) > data_end) {
+        id->src_port = th->source;
+        id->dst_port = th->dest;
+    } else if (iph->protocol == IPPROTO_UDP) {
+        struct udphdr *uh = l4;
+        if ((void *)(uh + 1) > data_end)
             return -1;
-        }
-        key->src_port = udp->source;
-        key->dst_port = udp->dest;
+        id->src_port = uh->source;
+        id->dst_port = uh->dest;
+    } else {
+        return -1;
     }
 
-    *pkt_len = (__u16)((__u64)data_end - (__u64)data);
     return 0;
 }
 
-static __always_inline __u64 isqrt_u64(__u64 x)
+static __always_inline void emit_event(const struct flow_key *id, __u64 now, __u64 win_pkts, __u64 delta, __u8 reason)
 {
-    __u64 op = x;
-    __u64 res = 0;
-    __u64 one = 1ULL << 62;
+    struct audit_event *evt = bpf_ringbuf_reserve(&events, sizeof(*evt), 0);
+    if (!evt)
+        return;
 
-    while (one > op) {
-        one >>= 2;
-    }
-
-#pragma unroll
-    for (int i = 0; i < 32; i++) {
-        if (one == 0) {
-            break;
-        }
-        if (op >= res + one) {
-            op -= res + one;
-            res = (res >> 1) + one;
-        } else {
-            res >>= 1;
-        }
-        one >>= 2;
-    }
-
-    return res;
+    evt->ts_ns = now;
+    evt->window_packets = win_pkts;
+    evt->pkt_delta_ns = delta;
+    evt->src_ip = id->src_ip;
+    evt->dst_ip = id->dst_ip;
+    evt->src_port = id->src_port;
+    evt->dst_port = id->dst_port;
+    evt->proto = id->proto;
+    evt->reason = reason;
+    bpf_ringbuf_submit(evt, 0);
 }
 
 SEC("xdp")
-int xdp_audit(struct xdp_md *ctx)
+int netflow_filter(struct xdp_md *ctx)
 {
     void *data = (void *)(long)ctx->data;
     void *data_end = (void *)(long)ctx->data_end;
 
-    struct flow_key key = {};
-    __u16 pkt_len = 0;
-
-    if (parse_l4(data, data_end, &key, &pkt_len) < 0) {
+    struct flow_key id = {};
+    if (parse_flow(data, data_end, &id) < 0)
         return XDP_PASS;
-    }
 
     __u64 now = bpf_ktime_get_ns();
+    __u64 pkt_len = (__u64)data_end - (__u64)data;
+
+    struct flow_metrics *m = bpf_map_lookup_elem(&flow_map, &id);
     __u64 delta_ns = 0;
-
-    struct flow_state *state = bpf_map_lookup_elem(&flow_tracker, &key);
-    if (state) {
-        if (now > state->last_seen_ns) {
-            delta_ns = now - state->last_seen_ns;
-        }
-        state->last_seen_ns = now;
+    if (m) {
+        delta_ns = (m->last_seen_ns > 0 && now > m->last_seen_ns) ? (now - m->last_seen_ns) : 0;
+        m->packets += 1;
+        m->bytes += pkt_len;
+        m->last_seen_ns = now;
     } else {
-        struct flow_state fresh = {
+        struct flow_metrics init = {
+            .packets = 1,
+            .bytes = pkt_len,
             .last_seen_ns = now,
+            .first_seen_ns = now,
         };
-        bpf_map_update_elem(&flow_tracker, &key, &fresh, BPF_ANY);
+        bpf_map_update_elem(&flow_map, &id, &init, BPF_ANY);
     }
 
-    if (delta_ns == 0) {
+    __u32 idx = 0;
+    struct spike_state *spike = bpf_map_lookup_elem(&spike_guard, &idx);
+    if (!spike)
         return XDP_PASS;
+
+    if (spike->window_start_ns == 0 || now - spike->window_start_ns >= NS_PER_SEC) {
+        spike->window_start_ns = now;
+        spike->pkt_count = 1;
+    } else {
+        spike->pkt_count += 1;
     }
 
-    __u32 stats_key = 0;
-    struct tvla_state *stats = bpf_map_lookup_elem(&timing_stats, &stats_key);
-    if (!stats) {
-        struct tvla_state init = {
-            .sample_count = 1,
-            .mean = delta_ns,
-            .m2 = 0,
-        };
-        bpf_map_update_elem(&timing_stats, &stats_key, &init, BPF_ANY);
-        return XDP_PASS;
-    }
+    if (spike->pkt_count >= SPIKE_THRESHOLD_PPS)
+        emit_event(&id, now, spike->pkt_count, delta_ns, 1);
 
-    __u64 old_mean = stats->mean;
-    __u64 old_count = stats->sample_count;
-
-    stats->sample_count = old_count + 1;
-    __u64 new_mean = old_mean + (delta_ns - old_mean) / stats->sample_count;
-    stats->mean = new_mean;
-
-    __u64 diff_old = delta_ns > old_mean ? delta_ns - old_mean : old_mean - delta_ns;
-    __u64 diff_new = delta_ns > new_mean ? delta_ns - new_mean : new_mean - delta_ns;
-    stats->m2 += diff_old * diff_new;
-
-    __u64 variance = 0;
-    __u32 tscore = 0;
-    __u8 leak_flag = 0;
-
-    if (stats->sample_count > 1) {
-        variance = stats->m2 / (stats->sample_count - 1);
-    }
-
-    if (stats->sample_count >= TVLA_MIN_SAMPLES && variance > 0) {
-        __u64 sigma = isqrt_u64(variance + EPSILON_NS);
-        __u64 abs_delta = delta_ns > stats->mean ? delta_ns - stats->mean : stats->mean - delta_ns;
-        if (sigma > 0) {
-            tscore = (__u32)(abs_delta / sigma);
-        }
-        if (tscore >= TVLA_ABS_T_THRESHOLD) {
-            leak_flag = 1;
-        }
-    }
-
-    if (leak_flag) {
-        struct audit_event evt = {
-            .ts_ns = now,
-            .src_ip = key.src_ip,
-            .dst_ip = key.dst_ip,
-            .src_port = key.src_port,
-            .dst_port = key.dst_port,
-            .proto = key.proto,
-            .pkt_len = pkt_len,
-            .delta_ns = delta_ns,
-            .mean_ns = stats->mean,
-            .variance_ns = variance,
-            .tvla_tscore = tscore,
-            .leak_flag = leak_flag,
-        };
-
-        bpf_perf_event_output(ctx, &audit_events, BPF_F_CURRENT_CPU, &evt, sizeof(evt));
-    }
+    if (delta_ns > 0 && delta_ns < 100)
+        emit_event(&id, now, spike->pkt_count, delta_ns, 2);
 
     return XDP_PASS;
 }


### PR DESCRIPTION
### Motivation
- Provide a hardware-software co-designed audit pipeline that captures line-rate timing at the XDP hook, aggregates per-CPU flow counters, and streams audit alerts into an Enclave-bound observability plane.
- Replace the previous bpftool/polling approach with a libbpf-based userspace bridge to load/attach the XDP program, consume ringbuf events, and expose Prometheus metrics inside the Enclave namespace.

### Description
- Kernel/XDP: added/rewrote `ebpf/xdp_audit.c` implementing `netflow_filter` which parses Ethernet/IPv4/TCP/UDP 5-tuples, maintains `flow_map` as `BPF_MAP_TYPE_PERCPU_HASH` sized for 1,048,576 flows, uses `bpf_ktime_get_ns()` for high-resolution timing, and emits structured audit alerts via a `BPF_MAP_TYPE_RINGBUF` named `events` for spike/low-delta anomalies.
- Userspace sidecar: replaced the polling sidecar with a libbpfgo-based agent in `ebpf/netflow-sidecar/main.go` that loads the CO-RE BPF object (`/opt/netflow/xdp_audit.bpf.o`), attaches `netflow_filter` via libbpf, iterates/aggregates per-CPU `flow_map` entries into top-N snapshots, exposes Prometheus `/metrics` (default :9400), and subscribes to ringbuf `events` to log `Trust Violation` audit entries.
- Build/runtime and topology: updated `ebpf/netflow-sidecar/Dockerfile`, `ebpf/netflow-sidecar/entrypoint.sh`, and `ebpf/netflow-sidecar/go.mod` (adds `libbpfgo`) so the container compiles the BPF object at startup and packages the sidecar binary; updated `docker-compose.yml` to run the sidecar as `xdp-auditor` in `network_mode: "service:enclave"` with `privileged: true` and mounts `/sys/fs/bpf` and `/lib/modules`, and added `BPF_OBJECT` env pointing at the compiled object; `README.md` rewritten with WSL2 quick-start and verification steps for the XDP→BPF→Enclave pipeline.

### Testing
- Ran `gofmt -w ebpf/netflow-sidecar/main.go` to format the Go source (succeeded).
- Ran `cd ebpf/netflow-sidecar && go mod tidy` to resolve Go deps, which failed due to the environment blocking fetch from `proxy.golang.org` (`Get "https://proxy.golang.org/...": Forbidden`).
- Manual inspection and local file checks were performed (file diffs and `nl`/`sed` outputs) and the changes were committed.  Automated build/run of the container and full integration tests were not executed here due to environment network/privilege constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993eb03f8948323a1ce2c66d2dfb560)