### PR TITLE
Add dispatcher evidence pipeline with SIMD masking, PKCS#11 signing and monitoring stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,92 +1,104 @@
-# Auditable Trust Object (ATO) for Drupal + MariaDB
+# Auditable Trust Object (ATO) Stack
 
-This stack delivers a local, high-throughput monitoring plane for Drupal/MariaDB with a trust chain:
+This repository now includes an end-to-end **Auditable Trust Object** pipeline for high-throughput flow capture and signed evidence export:
 
-**NIC (hardware)** → **XDP kernel hook (L1)** → **Per-CPU eBPF maps (L2)** → **SIMD masking** → **PKCS#11/HSM signatures (L3)** → **Enclave tunnel + Prometheus metrics**.
+1. **Kernel capture (L1/L2):** XDP NetFlow parser + Per-CPU hash map accounting.
+2. **Privacy + signing (L4/L5):** SIMD masking + PKCS#11 HSM signatures.
+3. **Secure transport:** Dispatcher, Prometheus, and Grafana on the Enclave SDN namespace.
+4. **App stack:** Drupal + MariaDB + Nginx isolated on `app_net`.
 
-## Dependency discovery and configuration
+## Key source files
 
-Install runtime/build dependencies (Ubuntu/WSL2):
-
-```bash
-sudo apt update
-sudo apt install -y clang llvm libbpf-dev linux-headers-$(uname -r) \
-  gcc make nasm pkg-config libssl-dev softhsm2 opensc docker.io docker-compose-plugin
-```
-
-Initialize a SoftHSM2 token and Ed25519 key:
-
-```bash
-softhsm2-util --init-token --slot 0 --label ato-token --so-pin 1234 --pin 1234
-pkcs11-tool --module /usr/lib/softhsm/libsofthsm2.so --login --pin 1234 \
-  --keypairgen --key-type EC:edwards25519 --label ato-ed25519 --usage-sign
-```
-
-Create env file:
-
-```bash
-cp .env.example .env
-```
-
-Add/update these values in `.env`:
-
-```dotenv
-ENCLAVE_ENROLMENT_KEY=...
-DRUPAL_DB_PASSWORD=...
-MARIADB_ROOT_PASSWORD=...
-PKCS11_MODULE_PATH=/usr/lib/softhsm/libsofthsm2.so
-PKCS11_PIN=1234
-HSM_KEY_LABEL=ato-ed25519
-```
-
-## Core files
-
-- `xdp_audit.c`: XDP NetFlow parser for IPv4/IPv6, per-CPU hash flow accounting, ring-buffer audit events.
-- `fast_mask.asm`: SIMD masking (`movdqu` + `pand`) for address privacy.
-- `dispatcher.c`: Per-CPU map aggregation, mandatory masking call per flow, PKCS#11 signing, Prometheus exposition.
-- `docker-compose.yml`: Enclave fabric + privileged dispatcher + local Drupal stack on `app_net`.
-
-## Bring up the stack
-
-```bash
-docker compose up -d --build
-```
-
-## Verify trust chain
-
-1) **XDP loaded**
-```bash
-docker logs xdp-auditor --tail=100
-```
-
-2) **Dispatcher producing signed evidence**
-```bash
-docker logs ato-dispatcher --tail=100
-```
-
-3) **Prometheus metrics over enclave interface**
-```bash
-docker exec enclave_agent wget -qO- http://localhost:9400/metrics
-```
-
-## Verify immutable audit log signatures
-
-Extract one evidence line's digestable payload and verify with OpenSSL (example flow):
-
-```bash
-openssl dgst -sha256 -verify public_key.pem -signature flow.sig flow_payload.bin
-```
-
-Expected output:
-
-```text
-Verified OK
-```
+- `xdp_audit.c` and `ebpf/xdp_audit.c`:
+  - Parses IPv4/IPv6 TCP+UDP packets at XDP hook.
+  - Maintains per-flow counters in `BPF_MAP_TYPE_PERCPU_HASH` (`flow_map`).
+  - Emits burst audit events via ring buffer.
+- `dispatcher.c`:
+  - Reads and aggregates per-CPU map values.
+  - Builds `evidence_t` records.
+  - Calls SIMD masking before hashing/signing.
+  - Exposes Prometheus metrics including verification success ratio.
+- `fast_mask.asm`:
+  - SSE (`movdqu`/`pand`) masking routine for IPv4 (/24) and IPv6 (/64).
+- `pkcs11_signer.c` + `pkcs11_signer.h`:
+  - PKCS#11 session management against real HSM or SoftHSM2.
+  - Signs SHA-256 digest bytes using token private key.
+- `docker-compose.yml`:
+  - Enclave, XDP auditor, dispatcher, SoftHSM2, Prometheus, Grafana.
+  - Drupal, MariaDB, Apache, Nginx on isolated `app_net`.
+- `grafana/dashboards/ato-signature-verification.json`:
+  - **Auditable Flow Rate** panel.
+  - **Signature Verification Success** panel.
 
 ## WSL2 quick start
 
-1. Use WSL2 kernel with eBPF support (`uname -r`).
-2. Start Docker Desktop with WSL integration.
-3. Install dependencies listed above inside WSL distro.
-4. Build and run `docker compose up -d --build`.
-5. Generate traffic to Drupal and inspect `/var/log/audit/signed_evidence.log` in dispatcher container.
+1. **Install WSL2 + Ubuntu** and verify kernel:
+   ```bash
+   uname -r
+   ```
+2. **Install build/runtime dependencies inside WSL2:**
+   ```bash
+   sudo apt update
+   sudo apt install -y clang llvm gcc make nasm pkg-config \
+     libbpf-dev libelf-dev libssl-dev softhsm2 opensc \
+     docker.io docker-compose-plugin linux-headers-$(uname -r)
+   ```
+3. **Enable Docker Desktop WSL integration** (or run docker engine in WSL).
+4. **Create `.env`**:
+   ```bash
+   cat > .env <<'ENV'
+   ENCLAVE_ENROLMENT_KEY=replace-me
+   DRUPAL_DB_PASSWORD=drupalpw
+   MARIADB_ROOT_PASSWORD=rootpw
+   PKCS11_MODULE_PATH=/usr/lib/softhsm/libsofthsm2.so
+   PKCS11_PIN=1234
+   HSM_KEY_LABEL=ato-ed25519
+   GRAFANA_ADMIN_USER=admin
+   GRAFANA_ADMIN_PASSWORD=admin
+   ENV
+   ```
+5. **Initialize SoftHSM2 token + signing key:**
+   ```bash
+   softhsm2-util --init-token --slot 0 --label ato-token --so-pin 1234 --pin 1234
+   pkcs11-tool --module /usr/lib/softhsm/libsofthsm2.so \
+     --login --pin 1234 \
+     --keypairgen --key-type EC:edwards25519 --label ato-ed25519 --usage-sign
+   ```
+6. **Start stack:**
+   ```bash
+   docker compose up -d --build
+   ```
+
+## Observability endpoints
+
+- Dispatcher metrics: `http://localhost:9400/metrics` (inside enclave network namespace).
+- Prometheus: `http://localhost:9090` (inside enclave namespace).
+- Grafana: `http://localhost:3000` (inside enclave namespace), dashboard title: **Auditable Trust Object Overview**.
+
+## Verify signed evidence with OpenSSL
+
+Dispatcher writes lines like:
+
+```text
+ts=... digest_sha256=<hex> verified=1 signature=<base64>
+```
+
+To verify a record:
+
+1. Extract `digest_sha256` (hex) and `signature` (base64) from one log line.
+2. Convert digest hex to binary:
+   ```bash
+   echo -n "<digest_sha256_hex>" | xxd -r -p > digest.bin
+   ```
+3. Convert signature base64 to raw bytes:
+   ```bash
+   echo -n "<signature_base64>" | base64 -d > flow.sig
+   ```
+4. Export public key from token (example with pkcs11-tool + OpenSSL workflow).
+5. Verify:
+   ```bash
+   openssl pkeyutl -verify -pubin -inkey public_key.pem \
+     -rawin -in digest.bin -sigfile flow.sig
+   ```
+
+`Signature Verified Successfully` indicates the evidence record matches the signed digest.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,20 @@ services:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus-data:/prometheus
 
+  grafana:
+    image: grafana/grafana:11.1.0
+    container_name: grafana
+    restart: unless-stopped
+    network_mode: "service:enclave"
+    depends_on: [prometheus]
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+    volumes:
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+
   db:
     image: mariadb:11.4
     container_name: mariadb
@@ -121,6 +135,8 @@ services:
     container_name: local-nginx
     restart: unless-stopped
     depends_on: [apache]
+    ports:
+      - "8080:80"
     networks: [app_net]
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro

--- a/grafana/dashboards/ato-signature-verification.json
+++ b/grafana/dashboards/ato-signature-verification.json
@@ -9,35 +9,55 @@
     {
       "datasource": {"type": "prometheus", "uid": "prometheus"},
       "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}}, "overrides": []},
-      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 0},
+      "gridPos": {"h": 9, "w": 14, "x": 0, "y": 0},
       "id": 1,
-      "options": {"displayMode": "gradient", "legend": {"displayMode": "list", "placement": "right"}, "pieType": "pie", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
       "targets": [
-        {"expr": "ato_verified_flows_total", "legendFormat": "Verified", "refId": "A"},
-        {"expr": "ato_unverified_flows_total", "legendFormat": "Unverified", "refId": "B"}
+        {"expr": "rate(ato_signed_evidence_total[1m])", "legendFormat": "signed evidence / sec", "refId": "A"}
       ],
-      "title": "Verified vs Unverified Flows",
-      "type": "piechart"
+      "title": "Auditable Flow Rate",
+      "type": "timeseries"
     },
     {
       "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}}, "overrides": []},
-      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 0},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": 0},
+              {"color": "green", "value": 0.99}
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 10, "x": 14, "y": 0},
       "id": 2,
-      "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
       "targets": [
-        {"expr": "rate(ato_signed_evidence_total[5m])", "legendFormat": "Signed evidence/sec", "refId": "A"}
+        {"expr": "ato_signature_verification_success", "legendFormat": "success", "refId": "A"}
       ],
-      "title": "Evidence Signing Rate",
-      "type": "timeseries"
+      "title": "Signature Verification Success",
+      "type": "stat"
     }
   ],
-  "refresh": "15s",
+  "refresh": "10s",
   "schemaVersion": 39,
   "style": "dark",
   "tags": ["audit", "hsm", "xdp"],
   "templating": {"list": []},
   "time": {"from": "now-1h", "to": "now"},
-  "title": "ATO Signature Verification",
-  "version": 1
+  "title": "Auditable Trust Object Overview",
+  "version": 2
 }

--- a/grafana/provisioning/datasources/datasources.yaml
+++ b/grafana/provisioning/datasources/datasources.yaml
@@ -2,6 +2,7 @@ apiVersion: 1
 
 datasources:
   - name: Prometheus
+    uid: prometheus
     type: prometheus
     access: proxy
     url: http://localhost:9090


### PR DESCRIPTION
### Motivation

- Provide an end-to-end Auditable Trust Object pipeline that captures per-CPU XDP flow data, applies privacy-preserving masking, produces SHA-256 evidence, and signs evidence with a PKCS#11 HSM (SoftHSM2 for dev). 
- Expose signing/verification metrics so an operator can monitor evidence throughput and signature verification health in Grafana.

### Description

- Expanded `dispatcher.c` to aggregate per-CPU `flow_map` entries including first/last-seen timestamps, build an `evidence_t` payload, call the SIMD masking routine before hashing, compute a SHA-256 digest over the evidence, and sign the digest via PKCS#11 using `pkcs11_signer.c`/`pkcs11_signer.h`.
- Added a Prometheus exporter field `ato_signature_verification_success` and counters `ato_verified_flows_total`, `ato_unverified_flows_total`, and `ato_signed_evidence_total` in `dispatcher.c` for monitoring.
- Implemented `fast_mask.asm` SSE masking helper (IPv4 /24, IPv6 /64) and integrated it into the dispatch signing flow.
- Updated `docker-compose.yml` to include Grafana (provisioned dashboards/datasources), SoftHSM2, Prometheus, the enclave network and the privileged dispatcher configuration, and exposed the app stack on an isolated `app_net`.
- Added/updated Grafana dashboard `grafana/dashboards/ato-signature-verification.json` and provisioning `grafana/provisioning/datasources/datasources.yaml` to visualize "Auditable Flow Rate" and "Signature Verification Success".
- Revised `README.md` with a WSL2 quick start, SoftHSM initialization steps, stack bringup, and steps to verify signed evidence with OpenSSL.

### Testing

- Successfully assembled the SIMD helper with `nasm -f elf64 -o /tmp/fast_mask.o fast_mask.asm` (succeeds).
- Validated the Grafana dashboard JSON with `python3 -m json.tool grafana/dashboards/ato-signature-verification.json >/tmp/dashboard.json` (succeeds).
- Attempted `make dispatcher LDFLAGS='-lbpf'` in this environment which failed due to missing libbpf headers (`bpf/bpf.h` not found), so the full native build could not be completed here (expected when dev headers are absent).
- Attempted `docker compose config` but the Docker CLI is not available in this execution environment, so container bring-up tests were not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993f2c9d240832390aad83d18c8f431)