### PR TITLE
Add ATO pipeline: 512-bit netflow HW parser, dispatcher batch-signing, PKCS#11 batch API, and deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,104 +1,90 @@
-# Auditable Trust Object (ATO) Stack
+# Auditable Trust Object (ATO)
 
-This repository now includes an end-to-end **Auditable Trust Object** pipeline for high-throughput flow capture and signed evidence export:
+This repository implements a full-stack **Auditable Trust Object** that binds together hardware parsing, eBPF enforcement, SIMD privacy controls, and HSM-backed signatures.
 
-1. **Kernel capture (L1/L2):** XDP NetFlow parser + Per-CPU hash map accounting.
-2. **Privacy + signing (L4/L5):** SIMD masking + PKCS#11 HSM signatures.
-3. **Secure transport:** Dispatcher, Prometheus, and Grafana on the Enclave SDN namespace.
-4. **App stack:** Drupal + MariaDB + Nginx isolated on `app_net`.
+## Source layers delivered
 
-## Key source files
+- **Hardware (`hardware/netflow_parser.v`)**
+  - 512-bit AXI-stream parser for 100Gbps pipelines.
+  - Extracts V7 tuple fields (src/dst IP, src/dst port, protocol, ToS, TCP flags).
+  - Carries NIC hardware timestamp metadata for downstream attestation.
+- **Kernel (`xdp_audit.c`)**
+  - XDP L1 filter parses IPv4/IPv6 TCP/UDP flows.
+  - L2 accounting map uses `BPF_MAP_TYPE_PERCPU_HASH` and emits ring-buffer alerts.
+- **Evidence (`dispatcher.c`, `fast_mask.asm`, `pkcs11_signer.c`)**
+  - SIMD assembly masking (`/24` IPv4, `/64` IPv6) before hashing.
+  - Batch signing path (`1000 flows/call`) to amortize HSM round-trip overhead.
+  - PKCS#11 signing via SoftHSM2 or physical HSM.
+- **Infrastructure (`docker-compose.yml`)**
+  - Enclave secure fabric and privileged dispatcher with `/sys/fs/bpf` mounted.
+  - SoftHSM2 + observability (Prometheus/Grafana).
+  - Isolated local stack (`Drupal + MariaDB + Apache + Nginx`) on `app_net`.
 
-- `xdp_audit.c` and `ebpf/xdp_audit.c`:
-  - Parses IPv4/IPv6 TCP+UDP packets at XDP hook.
-  - Maintains per-flow counters in `BPF_MAP_TYPE_PERCPU_HASH` (`flow_map`).
-  - Emits burst audit events via ring buffer.
-- `dispatcher.c`:
-  - Reads and aggregates per-CPU map values.
-  - Builds `evidence_t` records.
-  - Calls SIMD masking before hashing/signing.
-  - Exposes Prometheus metrics including verification success ratio.
-- `fast_mask.asm`:
-  - SSE (`movdqu`/`pand`) masking routine for IPv4 (/24) and IPv6 (/64).
-- `pkcs11_signer.c` + `pkcs11_signer.h`:
-  - PKCS#11 session management against real HSM or SoftHSM2.
-  - Signs SHA-256 digest bytes using token private key.
-- `docker-compose.yml`:
-  - Enclave, XDP auditor, dispatcher, SoftHSM2, Prometheus, Grafana.
-  - Drupal, MariaDB, Apache, Nginx on isolated `app_net`.
-- `grafana/dashboards/ato-signature-verification.json`:
-  - **Auditable Flow Rate** panel.
-  - **Signature Verification Success** panel.
+## Full trust chain
 
-## WSL2 quick start
+Evidence is generated and linked in the following chain:
 
-1. **Install WSL2 + Ubuntu** and verify kernel:
-   ```bash
-   uname -r
-   ```
-2. **Install build/runtime dependencies inside WSL2:**
-   ```bash
-   sudo apt update
-   sudo apt install -y clang llvm gcc make nasm pkg-config \
-     libbpf-dev libelf-dev libssl-dev softhsm2 opensc \
-     docker.io docker-compose-plugin linux-headers-$(uname -r)
-   ```
-3. **Enable Docker Desktop WSL integration** (or run docker engine in WSL).
-4. **Create `.env`**:
-   ```bash
-   cat > .env <<'ENV'
-   ENCLAVE_ENROLMENT_KEY=replace-me
-   DRUPAL_DB_PASSWORD=drupalpw
-   MARIADB_ROOT_PASSWORD=rootpw
-   PKCS11_MODULE_PATH=/usr/lib/softhsm/libsofthsm2.so
-   PKCS11_PIN=1234
-   HSM_KEY_LABEL=ato-ed25519
-   GRAFANA_ADMIN_USER=admin
-   GRAFANA_ADMIN_PASSWORD=admin
-   ENV
-   ```
-5. **Initialize SoftHSM2 token + signing key:**
-   ```bash
-   softhsm2-util --init-token --slot 0 --label ato-token --so-pin 1234 --pin 1234
-   pkcs11-tool --module /usr/lib/softhsm/libsofthsm2.so \
-     --login --pin 1234 \
-     --keypairgen --key-type EC:edwards25519 --label ato-ed25519 --usage-sign
-   ```
-6. **Start stack:**
-   ```bash
-   docker compose up -d --build
-   ```
+`[NIC Hardware Timestamp] -> [XDP Flow Hash Context] -> [BPF Map Checksum] -> [HSM Signature]`
 
-## Observability endpoints
+1. Hardware parser emits tuple + NIC timestamp metadata.
+2. XDP parser records per-flow counters in pinned per-CPU maps.
+3. Dispatcher folds map contents into `bpf_map_checksum` and builds evidence digest.
+4. Batch PKCS#11 signer produces token-backed signatures over SHA-256 evidence digests.
 
-- Dispatcher metrics: `http://localhost:9400/metrics` (inside enclave network namespace).
-- Prometheus: `http://localhost:9090` (inside enclave namespace).
-- Grafana: `http://localhost:3000` (inside enclave namespace), dashboard title: **Auditable Trust Object Overview**.
+## WSL2 deployment
 
-## Verify signed evidence with OpenSSL
+### 1) Install required packages
 
-Dispatcher writes lines like:
-
-```text
-ts=... digest_sha256=<hex> verified=1 signature=<base64>
+```bash
+sudo apt update
+sudo apt install -y clang llvm gcc make nasm pkg-config \
+  libbpf-dev libelf-dev libssl-dev softhsm2 opensc \
+  docker.io docker-compose-plugin linux-headers-$(uname -r)
 ```
 
-To verify a record:
+### 2) Configure environment
 
-1. Extract `digest_sha256` (hex) and `signature` (base64) from one log line.
-2. Convert digest hex to binary:
-   ```bash
-   echo -n "<digest_sha256_hex>" | xxd -r -p > digest.bin
-   ```
-3. Convert signature base64 to raw bytes:
-   ```bash
-   echo -n "<signature_base64>" | base64 -d > flow.sig
-   ```
-4. Export public key from token (example with pkcs11-tool + OpenSSL workflow).
-5. Verify:
-   ```bash
-   openssl pkeyutl -verify -pubin -inkey public_key.pem \
-     -rawin -in digest.bin -sigfile flow.sig
-   ```
+```bash
+cat > .env <<'ENV'
+ENCLAVE_ENROLMENT_KEY=replace-me
+DRUPAL_DB_PASSWORD=drupalpw
+MARIADB_ROOT_PASSWORD=rootpw
+PKCS11_MODULE_PATH=/usr/lib/softhsm/libsofthsm2.so
+PKCS11_PIN=1234
+HSM_KEY_LABEL=ato-ed25519
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=admin
+ENV
+```
 
-`Signature Verified Successfully` indicates the evidence record matches the signed digest.
+### 3) Initialize SoftHSM2 token
+
+```bash
+softhsm2-util --init-token --slot 0 --label ato-token --so-pin 1234 --pin 1234
+pkcs11-tool --module /usr/lib/softhsm/libsofthsm2.so \
+  --login --pin 1234 \
+  --keypairgen --key-type EC:edwards25519 --label ato-ed25519 --usage-sign
+```
+
+### 4) Build and run
+
+```bash
+docker compose up -d --build
+```
+
+### 5) Optional local binary build
+
+```bash
+make dispatcher LDFLAGS="-lbpf"
+```
+
+## Runtime verification
+
+Signed records are appended to `/var/log/audit/signed_evidence.log` and include:
+
+- `bpf_map_checksum`
+- `digest_sha256`
+- `verified`
+- `signature` (base64)
+
+To verify digest/signature pairs, export the HSM public key and use `openssl pkeyutl -verify` on the digest bytes.

--- a/docker/dispatcher/Dockerfile
+++ b/docker/dispatcher/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    build-essential clang llvm libbpf-dev libelf-dev libssl-dev libpkcs11-helper1-dev pkg-config ca-certificates && \
+    build-essential clang llvm nasm libbpf-dev libelf-dev libssl-dev libpkcs11-helper1-dev pkg-config ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/ato

--- a/hardware/netflow_parser.v
+++ b/hardware/netflow_parser.v
@@ -1,0 +1,113 @@
+module netflow_parser (
+    input  logic         clk,
+    input  logic         rst_n,
+    input  logic [511:0] s_axis_tdata,
+    input  logic [63:0]  s_axis_tkeep,
+    input  logic         s_axis_tvalid,
+    input  logic         s_axis_tlast,
+    output logic         s_axis_tready,
+    output logic         tuple_valid,
+    output logic [127:0] src_ip,
+    output logic [127:0] dst_ip,
+    output logic [15:0]  src_port,
+    output logic [15:0]  dst_port,
+    output logic [7:0]   l4_proto,
+    output logic [7:0]   ip_tos,
+    output logic [7:0]   tcp_flags,
+    output logic [63:0]  hw_ts_ns,
+    output logic [31:0]  parser_meta
+);
+
+// 100Gbps AXI-stream parser targeting one tuple extraction per cycle.
+// Exposes a V7 tuple: src_ip, dst_ip, src_port, dst_port, proto, ToS, TCP flags.
+// hw_ts_ns is expected to be stamped by the upstream NIC pipeline and packed into
+// the high dword lane of beat-0 metadata (bits [511:448]).
+
+localparam logic [15:0] ETHERTYPE_IPV4 = 16'h0800;
+localparam logic [15:0] ETHERTYPE_IPV6 = 16'h86DD;
+
+logic [15:0] eth_type;
+logic [3:0]  ipv4_ihl;
+logic [7:0]  ipv4_proto;
+logic [7:0]  ipv6_next_hdr;
+logic [7:0]  tos_q;
+logic [7:0]  flags_q;
+logic [127:0] src_ip_q;
+logic [127:0] dst_ip_q;
+logic [15:0] src_port_q;
+logic [15:0] dst_port_q;
+logic tuple_hit;
+
+assign s_axis_tready = 1'b1;
+
+always_comb begin
+    eth_type     = s_axis_tdata[111:96];
+    ipv4_ihl     = s_axis_tdata[115:112];
+    ipv4_proto   = s_axis_tdata[191:184];
+    ipv6_next_hdr= s_axis_tdata[167:160];
+    tuple_hit    = 1'b0;
+
+    src_ip_q     = '0;
+    dst_ip_q     = '0;
+    src_port_q   = '0;
+    dst_port_q   = '0;
+    tos_q        = '0;
+    flags_q      = '0;
+
+    if (s_axis_tvalid && s_axis_tkeep[53:0] != 64'b0) begin
+        if (eth_type == ETHERTYPE_IPV4) begin
+            tuple_hit  = (ipv4_proto == 8'd6) || (ipv4_proto == 8'd17);
+            src_ip_q[31:0] = s_axis_tdata[239:208];
+            dst_ip_q[31:0] = s_axis_tdata[271:240];
+            tos_q = s_axis_tdata[127:120];
+
+            // Parse source/destination ports for common IHL=5 fast path.
+            // Variable IHL fallback is bounded to first 64B beat.
+            if (ipv4_ihl == 4'd5) begin
+                src_port_q = s_axis_tdata[287:272];
+                dst_port_q = s_axis_tdata[303:288];
+                if (ipv4_proto == 8'd6) begin
+                    flags_q = s_axis_tdata[391:384];
+                end
+            end
+        end else if (eth_type == ETHERTYPE_IPV6) begin
+            tuple_hit  = (ipv6_next_hdr == 8'd6) || (ipv6_next_hdr == 8'd17);
+            src_ip_q   = s_axis_tdata[319:192];
+            dst_ip_q   = s_axis_tdata[447:320];
+            src_port_q = s_axis_tdata[463:448];
+            dst_port_q = s_axis_tdata[479:464];
+            tos_q      = {s_axis_tdata[123:120], s_axis_tdata[127:124]};
+            if (ipv6_next_hdr == 8'd6) begin
+                flags_q = s_axis_tdata[503:496];
+            end
+        end
+    end
+end
+
+always_ff @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+        tuple_valid <= 1'b0;
+        src_ip      <= '0;
+        dst_ip      <= '0;
+        src_port    <= '0;
+        dst_port    <= '0;
+        l4_proto    <= '0;
+        ip_tos      <= '0;
+        tcp_flags   <= '0;
+        hw_ts_ns    <= '0;
+        parser_meta <= '0;
+    end else begin
+        tuple_valid <= tuple_hit;
+        src_ip      <= src_ip_q;
+        dst_ip      <= dst_ip_q;
+        src_port    <= src_port_q;
+        dst_port    <= dst_port_q;
+        l4_proto    <= (eth_type == ETHERTYPE_IPV4) ? ipv4_proto : ipv6_next_hdr;
+        ip_tos      <= tos_q;
+        tcp_flags   <= flags_q;
+        hw_ts_ns    <= s_axis_tdata[511:448];
+        parser_meta <= {8'(eth_type == ETHERTYPE_IPV6), 7'd0, s_axis_tlast, s_axis_tkeep[15:0]};
+    end
+end
+
+endmodule

--- a/pkcs11_signer.h
+++ b/pkcs11_signer.h
@@ -5,6 +5,12 @@
 
 int pkcs11_initialize_from_env(void);
 int sign_log_hsm(unsigned char *data, size_t len);
+int sign_log_hsm_batch(const unsigned char *digests,
+                       size_t digest_len,
+                       size_t batch_size,
+                       unsigned char *signatures,
+                       size_t *signature_lens,
+                       size_t signature_stride);
 const unsigned char *pkcs11_last_signature(size_t *len_out);
 void pkcs11_cleanup(void);
 


### PR DESCRIPTION
### Motivation
- Provide an end-to-end Auditable Trust Object (ATO) connecting NIC hardware tuple extraction → XDP capture → signed evidence with HSM-backed attestations.
- Achieve line-rate/scale goals by extracting V7 tuples in a 512-bit AXI beat and amortizing HSM latency via batch signing (1000 flows/call).
- Preserve privacy before signing using a fast SIMD masking primitive and bind software evidence to kernel state with a BPF map checksum.

### Description
- Added a 512-bit AXI-stream hardware parser `hardware/netflow_parser.v` that extracts V7 tuple fields (IPv4/IPv6 src/dst, ports, L4 proto, ToS, TCP flags) and carries NIC timestamp metadata in the high dword lane. 
- Reworked `dispatcher.c` to aggregate per-CPU BPF map entries, compute a `bpf_map_checksum`, build `evidence_t` records, apply `fast_mask_ip_pair` masking, compute SHA-256 digests, and sign evidence in batches (`SIGN_BATCH_SIZE=1000`) before emitting signed log lines. 
- Extended PKCS#11 signer with a batch API: added `sign_log_hsm_batch(...)` and implemented batch signing in `pkcs11_signer.c` and declared it in `pkcs11_signer.h`. Also hardened the signer initialization/cleanup flow for environment-driven configuration. 
- Included the SIMD masking assembly helper `fast_mask.asm` usage and ensured dispatcher links to its object in the build. 
- Updated `docker/dispatcher/Dockerfile` to include `nasm` so container builds produce the SIMD object, and updated `README.md` with the full trust chain, WSL2 build/run steps (including `libbpf-dev` and `nasm`), and verification guidance. 

### Testing
- Ran `make clean && make dispatcher LDFLAGS='-lbpf'` in the workspace; it failed in this environment because `bpf/bpf.h` is not available on the host include path (expected on WSL2/container with `libbpf-dev`). (failed)
- Compiled the signer and assembled SIMD helper with `gcc -O2 -Wall -Wextra -c pkcs11_signer.c -o /tmp/pkcs11_signer.o && nasm -f elf64 -o /tmp/fast_mask.o fast_mask.asm`; both steps completed successfully. (passed)
- Attempted to run an HDL smoke parse with `iverilog -g2012 -t null hardware/netflow_parser.v` but `iverilog` is not installed in this environment; HDL lint/RTL sim should be executed in a proper toolchain. (not run)
- Verified repository build integration where possible (container `Dockerfile` adjusted to include `nasm`); full end-to-end stack `docker compose up -d --build` should be run in the target environment (WSL2 or Linux) after installing listed dependencies in `README.md`. (untested end-to-end)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993f44292a08323aa828f4073d180a6)