### PR TITLE
Add reproducible QEMU hardware integration harness and guest image build workflow

### DIFF
--- a/docs/qemu-harness.md
+++ b/docs/qemu-harness.md
@@ -1,0 +1,66 @@
+# QEMU Hardware Harness Guide
+
+This guide provisions a reproducible local environment where `make hw-test` boots the full IĀTŌ stack in QEMU and runs `pytest -m hw` with `IATO_HW_MODE=1`.
+
+## 1) Install host dependencies
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+  qemu-system-aarch64 swtpm tpm2-tools \
+  libvirt-clients virt-manager \
+  qemu-utils libguestfs-tools netcat-openbsd python3-pip
+```
+
+## 2) Build libspdm responder
+
+Use the flow in `docs/qemu-spdm.md` and ensure this output exists:
+
+```text
+build/libspdm/bin/spdm_responder_emu
+```
+
+## 3) Build custom EL2 hypervisor
+
+Build your project-specific EL2 image and place it at:
+
+```text
+build/el2/iato-el2.bin
+```
+
+## 4) Fetch Python wheels (internet required)
+
+```bash
+make fetch-wheels
+```
+
+## 5) Build guest image (offline-capable after wheel fetch)
+
+```bash
+make build-guest-image
+```
+
+## 6) Run hardware tests
+
+```bash
+make hw-test
+```
+
+## 7) Review results
+
+```bash
+cat tests/hw-results.md
+```
+
+## Environment variables
+
+- `IATO_GUEST_IMAGE`: path to guest qcow2 image (default: `build/guest/guest.img`)
+- `IATO_EL2_BIN`: path to EL2 hypervisor binary (default: `build/el2/iato-el2.bin`)
+- `IATO_SPDM_RESPONDER`: path to libspdm responder (default: `build/libspdm/bin/spdm_responder_emu`)
+- `IATO_BOOT_TIMEOUT_S`: guest boot timeout in seconds (default: `120`)
+- `IATO_TEST_TIMEOUT_S`: hardware test timeout in seconds (default: `300`)
+
+## Notes
+
+- `scripts/qemu-harness.sh` performs only local orchestration; it does not download assets.
+- If preflight fails, the harness exits with setup pointers back to this document.

--- a/scripts/build-guest-image.sh
+++ b/scripts/build-guest-image.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${ROOT_DIR}/build/guest"
+BASE_IMG="${BUILD_DIR}/base.img"
+RAW_IMG="${BUILD_DIR}/guest-raw.img"
+FINAL_IMG="${BUILD_DIR}/guest.img"
+CACHE_DIR="${BUILD_DIR}/apt-cache"
+WHEEL_DIR="${BUILD_DIR}/wheels"
+
+BASE_URL="https://cloud-images.ubuntu.com/minimal/releases/24.04/release"
+BASE_FILE="ubuntu-24.04-minimal-cloudimg-arm64.img"
+SHA_FILE="SHA256SUMS"
+
+mkdir -p "${BUILD_DIR}" "${CACHE_DIR}" "${WHEEL_DIR}" "${ROOT_DIR}/build/el2"
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "[build-guest][error] missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+need_cmd curl
+need_cmd sha256sum
+need_cmd qemu-img
+need_cmd virt-customize
+
+sha_expected="$(curl -fsSL "${BASE_URL}/${SHA_FILE}" | awk -v f="${BASE_FILE}" '$2==f {print $1}')"
+if [[ -z "${sha_expected}" ]]; then
+  echo "[build-guest][error] unable to resolve expected checksum for ${BASE_FILE}" >&2
+  exit 1
+fi
+
+if [[ -f "${BASE_IMG}" ]]; then
+  sha_actual="$(sha256sum "${BASE_IMG}" | awk '{print $1}')"
+  if [[ "${sha_actual}" != "${sha_expected}" ]]; then
+    echo "[build-guest] cached base image checksum mismatch; refreshing"
+    rm -f "${BASE_IMG}"
+  fi
+fi
+
+if [[ ! -f "${BASE_IMG}" ]]; then
+  curl -fL "${BASE_URL}/${BASE_FILE}" -o "${BASE_IMG}"
+fi
+
+sha_actual="$(sha256sum "${BASE_IMG}" | awk '{print $1}')"
+if [[ "${sha_actual}" != "${sha_expected}" ]]; then
+  echo "[build-guest][error] checksum verification failed for base image" >&2
+  exit 1
+fi
+
+if [[ ! -d "${WHEEL_DIR}" ]] || ! find "${WHEEL_DIR}" -maxdepth 1 -name '*.whl' | grep -q .; then
+  echo "[build-guest][error] wheel cache not found; run make fetch-wheels first" >&2
+  exit 1
+fi
+
+rm -f "${RAW_IMG}" "${FINAL_IMG}"
+qemu-img convert -f qcow2 -O raw "${BASE_IMG}" "${RAW_IMG}"
+
+virt-customize -a "${RAW_IMG}" \
+  --run-command 'mkdir -p /etc/apt/apt.conf.d && printf "Dir::Cache::archives \"/var/cache/apt/archives\";\n" > /etc/apt/apt.conf.d/99iato-cache' \
+  --copy-in "${CACHE_DIR}/:/var/cache/apt/archives" \
+  --run-command 'apt-get update && apt-get install -y python3 python3-pip tpm2-tools tpm2-pytss' \
+  --mkdir /opt/iato \
+  --copy-in "${ROOT_DIR}/src:/opt/iato" \
+  --copy-in "${ROOT_DIR}/tests:/opt/iato" \
+  --copy-in "${ROOT_DIR}/pyproject.toml:/opt/iato" \
+  --mkdir /opt/iato/scripts \
+  --copy-in "${ROOT_DIR}/scripts/activate-dotnet-offline.sh:/opt/iato/scripts" \
+  --copy-in "${WHEEL_DIR}:/opt/iato/build/guest" \
+  --run-command 'python3 -m pip install --no-index --find-links /opt/iato/build/guest/wheels cryptography==42.0.5 pytest==8.1.0 pytest-cov==5.0.0' \
+  --run-command 'cat > /etc/rc.local <<"RCLOCAL"\n#!/bin/sh -e\necho "[guest-ready]" > /dev/hvc0\nexit 0\nRCLOCAL\nchmod +x /etc/rc.local'
+
+qemu-img convert -f raw -O qcow2 "${RAW_IMG}" "${FINAL_IMG}"
+qemu-img resize "${FINAL_IMG}" 8G >/dev/null
+
+size_mb="$(du -m "${FINAL_IMG}" | awk '{print $1}')"
+echo "[build-guest] OK: build/guest/guest.img (${size_mb}MB)"

--- a/scripts/fetch-wheels.sh
+++ b/scripts/fetch-wheels.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WHEEL_DIR="${ROOT_DIR}/build/guest/wheels"
+mkdir -p "${WHEEL_DIR}"
+
+python3 -m pip download \
+  --platform manylinux_2_28_aarch64 \
+  --python-version 311 \
+  --only-binary :all: \
+  --dest "${WHEEL_DIR}" \
+  cryptography==42.0.5 pytest==8.1.0 pytest-cov==5.0.0 cffi tpm2-pytss
+
+count="$(find "${WHEEL_DIR}" -maxdepth 1 -type f -name '*.whl' | wc -l | tr -d ' ')"
+echo "[fetch-wheels] OK: ${count} wheels downloaded to build/guest/wheels/"

--- a/scripts/qemu-harness.sh
+++ b/scripts/qemu-harness.sh
@@ -1,0 +1,368 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RESULT_DIR="${ROOT_DIR}/build/hw-results"
+RESULT_MD="${ROOT_DIR}/tests/hw-results.md"
+
+IATO_SPDM_RESPONDER="${IATO_SPDM_RESPONDER:-${ROOT_DIR}/build/libspdm/bin/spdm_responder_emu}"
+IATO_GUEST_IMAGE="${IATO_GUEST_IMAGE:-${ROOT_DIR}/build/guest/guest.img}"
+IATO_EL2_BIN="${IATO_EL2_BIN:-${ROOT_DIR}/build/el2/iato-el2.bin}"
+IATO_BOOT_TIMEOUT_S="${IATO_BOOT_TIMEOUT_S:-120}"
+IATO_TEST_TIMEOUT_S="${IATO_TEST_TIMEOUT_S:-300}"
+
+SWTPM_DIR="/tmp/iato-swtpm"
+SWTPM_SOCK="${SWTPM_DIR}/swtpm.sock"
+SWTPM_PID="${SWTPM_DIR}/swtpm.pid"
+SPDM_SOCK="/tmp/iato-spdm.sock"
+SPDM_PID="/tmp/iato-spdm.pid"
+SPDM_LOG="/tmp/iato-spdm.log"
+QEMU_PID="/tmp/iato-qemu.pid"
+QEMU_LOG="/tmp/iato-qemu.log"
+CONSOLE_SOCK="/tmp/iato-console.sock"
+CONSOLE_LOG="/tmp/iato-console.log"
+EXIT_FILE="/tmp/iato-hw-exitcode"
+
+PYTEST_XML="${RESULT_DIR}/hw-pytest.xml"
+PYTEST_LOG="${RESULT_DIR}/hw-pytest.log"
+
+mkdir -p "${RESULT_DIR}"
+rm -f "${SPDM_SOCK}" "${CONSOLE_SOCK}" "${QEMU_PID}" "${SPDM_PID}" "${EXIT_FILE}" "${CONSOLE_LOG}" "${PYTEST_XML}" "${PYTEST_LOG}"
+
+HW_EXIT=1
+
+log() { echo "[harness] $*"; }
+err() { echo "[harness][error] $*" >&2; }
+
+teardown() {
+  set +e
+  if [[ -S "${CONSOLE_SOCK}" ]]; then
+    printf 'poweroff\n' | nc -U "${CONSOLE_SOCK}" >/dev/null 2>&1 || true
+  fi
+
+  if [[ -f "${QEMU_PID}" ]]; then
+    qpid="$(cat "${QEMU_PID}" 2>/dev/null || true)"
+    if [[ -n "${qpid}" ]] && kill -0 "${qpid}" >/dev/null 2>&1; then
+      for _ in $(seq 1 10); do
+        kill -0 "${qpid}" >/dev/null 2>&1 || break
+        sleep 1
+      done
+      kill -0 "${qpid}" >/dev/null 2>&1 && kill -9 "${qpid}" >/dev/null 2>&1 || true
+    fi
+  fi
+
+  if [[ -f "${SWTPM_PID}" ]]; then
+    spid="$(cat "${SWTPM_PID}" 2>/dev/null || true)"
+    [[ -n "${spid}" ]] && kill "${spid}" >/dev/null 2>&1 || true
+  fi
+
+  if [[ -f "${SPDM_PID}" ]]; then
+    ppid="$(cat "${SPDM_PID}" 2>/dev/null || true)"
+    [[ -n "${ppid}" ]] && kill "${ppid}" >/dev/null 2>&1 || true
+  fi
+
+  rm -f "${SWTPM_SOCK}" "${SPDM_SOCK}" "${CONSOLE_SOCK}" "${SWTPM_PID}" "${SPDM_PID}" "${QEMU_PID}" "${EXIT_FILE}"
+  log "teardown complete"
+}
+trap teardown EXIT
+
+preflight_fail() {
+  err "preflight failed: $1"
+  err "see docs/qemu-harness.md for setup instructions"
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || preflight_fail "missing command: $1"
+}
+
+require_cmd qemu-system-aarch64
+require_cmd swtpm
+require_cmd nc
+require_cmd python3
+
+qemu_version="$(qemu-system-aarch64 --version | head -n1)"
+qemu_ver_num="$(echo "${qemu_version}" | sed -E 's/.*version ([0-9]+\.[0-9]+).*/\1/')"
+python3 - <<PY || preflight_fail "qemu-system-aarch64 version must be >= 7.2 (found ${qemu_ver_num})"
+import sys
+def v(x):
+    try:
+        return tuple(int(i) for i in x.split("."))
+    except Exception:
+        return (0,0)
+sys.exit(0 if v("${qemu_ver_num}") >= v("7.2") else 1)
+PY
+
+[[ -x "${IATO_SPDM_RESPONDER}" ]] || preflight_fail "SPDM responder missing or not executable: ${IATO_SPDM_RESPONDER}"
+[[ -f "${IATO_GUEST_IMAGE}" ]] || preflight_fail "guest image not found: ${IATO_GUEST_IMAGE}"
+[[ -f "${IATO_EL2_BIN}" ]] || preflight_fail "EL2 binary not found: ${IATO_EL2_BIN}"
+
+mkdir -p "${SWTPM_DIR}"
+swtpm socket \
+  --tpmstate dir="${SWTPM_DIR}" \
+  --ctrl type=unixio,path="${SWTPM_SOCK}" \
+  --tpm2 --daemon --pid "${SWTPM_PID}"
+
+started=0
+for _ in $(seq 1 50); do
+  if nc -z -U "${SWTPM_SOCK}" >/dev/null 2>&1; then
+    started=1
+    break
+  fi
+  sleep 0.1
+done
+[[ "${started}" -eq 1 ]] || { err "swtpm did not start"; exit 1; }
+
+"${IATO_SPDM_RESPONDER}" --trans socket --socket-path "${SPDM_SOCK}" >>"${SPDM_LOG}" 2>&1 &
+echo $! > "${SPDM_PID}"
+
+started=0
+for _ in $(seq 1 50); do
+  if nc -z -U "${SPDM_SOCK}" >/dev/null 2>&1; then
+    started=1
+    break
+  fi
+  sleep 0.1
+done
+[[ "${started}" -eq 1 ]] || { err "spdm responder did not start"; exit 1; }
+
+qemu-system-aarch64 \
+  -machine virt,iommu=smmuv3,secure=on \
+  -cpu cortex-a57 \
+  -m 2G \
+  -smp 2 \
+  -bios "${IATO_EL2_BIN}" \
+  -drive file="${IATO_GUEST_IMAGE}",format=qcow2,if=virtio \
+  -chardev socket,id=chrtpm,path="${SWTPM_SOCK}" \
+  -tpmdev emulator,id=tpm0,chardev=chrtpm \
+  -device tpm-tis,tpmdev=tpm0 \
+  -chardev socket,id=spdm,path="${SPDM_SOCK}" \
+  -device virtio-serial \
+  -chardev socket,id=console,path="${CONSOLE_SOCK}",server,nowait \
+  -device virtconsole,chardev=console \
+  -device virtio-net-pci,iommu_platform=on,ats=on \
+  -nographic \
+  -no-reboot \
+  -pidfile "${QEMU_PID}" \
+  >>"${QEMU_LOG}" 2>&1 &
+
+python3 - <<PY
+import base64
+import os
+import re
+import socket
+import sys
+import time
+
+sock_path = "${CONSOLE_SOCK}"
+boot_timeout = int("${IATO_BOOT_TIMEOUT_S}")
+test_timeout = int("${IATO_TEST_TIMEOUT_S}")
+log_path = "${CONSOLE_LOG}"
+exit_file = "${EXIT_FILE}"
+out_xml = "${PYTEST_XML}"
+out_log = "${PYTEST_LOG}"
+
+start = time.time()
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+while True:
+    try:
+        s.connect(sock_path)
+        break
+    except OSError:
+        if time.time() - start > boot_timeout:
+            print("BOOT_TIMEOUT", file=sys.stderr)
+            sys.exit(2)
+        time.sleep(0.2)
+
+s.settimeout(0.2)
+stream = b""
+ready = False
+hw_done = False
+exit_code = 1
+artifacts = {}
+current_name = None
+current_data = []
+
+with open(log_path, "wb") as lf:
+    while True:
+        try:
+            data = s.recv(4096)
+            if not data:
+                break
+            lf.write(data)
+            lf.flush()
+            stream += data
+        except socket.timeout:
+            pass
+
+        text = stream.decode("utf-8", errors="ignore")
+        lines = text.split("\n")
+        stream = lines.pop().encode("utf-8", errors="ignore")
+
+        for line in lines:
+            if not ready and "[guest-ready]" in line:
+                ready = True
+                cmd = "\n".join([
+                    "cd /opt/iato",
+                    "export IATO_HW_MODE=1",
+                    "export IATO_TPM_SIM=0",
+                    "export IATO_MANA_SIM_MMIO=0",
+                    "export IATO_SPDM_SOCKET=/tmp/iato-spdm.sock",
+                    "export IATO_EL2_TIMER_DEV=/dev/iato-el2-timer",
+                    "pytest -m hw -v --tb=short --junitxml=/tmp/hw-pytest.xml 2>&1 | tee /tmp/hw-pytest.log",
+                    "echo [hw-test-done] exit=$?",
+                    "echo [artifact-begin] hw-pytest.log",
+                    "base64 -w0 /tmp/hw-pytest.log || true; echo",
+                    "echo [artifact-end] hw-pytest.log",
+                    "echo [artifact-begin] hw-pytest.xml",
+                    "base64 -w0 /tmp/hw-pytest.xml || true; echo",
+                    "echo [artifact-end] hw-pytest.xml",
+                    "echo [artifact-complete]",
+                    "",
+                ])
+                s.sendall(cmd.encode())
+
+            m = re.search(r"\[hw-test-done\] exit=(\d+)", line)
+            if m:
+                exit_code = int(m.group(1))
+                hw_done = True
+
+            m = re.match(r"\[artifact-begin\] (.+)", line.strip())
+            if m:
+                current_name = m.group(1)
+                current_data = []
+                continue
+
+            m = re.match(r"\[artifact-end\] (.+)", line.strip())
+            if m and current_name == m.group(1):
+                artifacts[current_name] = "".join(current_data)
+                current_name = None
+                current_data = []
+                continue
+
+            if current_name is not None:
+                current_data.append(line.strip())
+
+            if hw_done and "[artifact-complete]" in line:
+                with open(exit_file, "w", encoding="utf-8") as f:
+                    f.write(str(exit_code))
+                for name, payload in artifacts.items():
+                    if not payload:
+                        continue
+                    out = out_log if name.endswith(".log") else out_xml
+                    with open(out, "wb") as fh:
+                        fh.write(base64.b64decode(payload.encode()))
+                sys.exit(0)
+
+        if not ready and time.time() - start > boot_timeout:
+            print("BOOT_TIMEOUT", file=sys.stderr)
+            sys.exit(2)
+        if ready and time.time() - start > (boot_timeout + test_timeout):
+            print("TEST_TIMEOUT", file=sys.stderr)
+            sys.exit(3)
+PY
+
+py_rc=$?
+if [[ "${py_rc}" -eq 2 ]]; then
+  err "guest ready signal timeout"
+  tail -n 50 "${QEMU_LOG}" >&2 || true
+  exit 1
+elif [[ "${py_rc}" -eq 3 ]]; then
+  err "hw test completion timeout"
+  exit 1
+elif [[ "${py_rc}" -ne 0 ]]; then
+  err "console harness failed"
+  exit 1
+fi
+
+if [[ -f "${EXIT_FILE}" ]]; then
+  HW_EXIT="$(cat "${EXIT_FILE}")"
+fi
+
+python3 - <<PY
+import datetime as dt
+import hashlib
+import os
+import subprocess
+import xml.etree.ElementTree as ET
+
+result_md = "${RESULT_MD}"
+xml_path = "${PYTEST_XML}"
+qemu_version = "${qemu_version}"
+
+counts = {"total": 0, "failed": 0, "skipped": 0, "passed": 0}
+failed_tests = []
+if os.path.exists(xml_path):
+    root = ET.parse(xml_path).getroot()
+    suite = root if root.tag == "testsuite" else root.find("testsuite")
+    if suite is not None:
+        counts["total"] = int(suite.attrib.get("tests", 0))
+        counts["failed"] = int(suite.attrib.get("failures", 0)) + int(suite.attrib.get("errors", 0))
+        counts["skipped"] = int(suite.attrib.get("skipped", 0))
+        counts["passed"] = counts["total"] - counts["failed"] - counts["skipped"]
+        for tc in suite.findall("testcase"):
+            fail = tc.find("failure") or tc.find("error")
+            if fail is not None:
+                name = f"{tc.attrib.get('classname','')}.{tc.attrib.get('name','')}".strip(".")
+                msg = (fail.attrib.get("message") or (fail.text or "")).strip().splitlines()[0] if (fail.attrib.get("message") or fail.text) else "failure"
+                failed_tests.append(f"{name}: {msg}")
+
+print(f"[harness] hw tests: total={counts['total']} passed={counts['passed']} failed={counts['failed']} skipped={counts['skipped']}")
+
+def sha(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+guest_sha = sha("${IATO_GUEST_IMAGE}")
+el2_sha = sha("${IATO_EL2_BIN}")
+
+commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+branch = subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"], text=True).strip()
+
+def _read(path):
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8", errors="ignore") as f:
+            return f.read()
+    return ""
+
+spdm_log = _read("${SPDM_LOG}")
+qemu_log = _read("${QEMU_LOG}")
+console_log = _read("${CONSOLE_LOG}")
+
+pcr_extended = "YES" if "PCR" in qemu_log or "PCR" in console_log else "NO"
+spdm_attested = "YES" if "ATTESTED" in spdm_log or "ATTESTED" in console_log else "NO"
+ste_writes = qemu_log.count("STE")
+el2_intervals = console_log.count("iato-el2-timer")
+
+verdict = "PASS" if int("${HW_EXIT}") == 0 and counts["failed"] == 0 else "FAIL"
+if counts["total"] == 0:
+    verdict = "UNPROVISIONED"
+
+with open(result_md, "w", encoding="utf-8") as out:
+    out.write("# IĀTŌ-V7 Hardware Integration Test Results\n")
+    out.write(f"Date (UTC): {dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()}\n")
+    out.write(f"QEMU version: {qemu_version}\n")
+    out.write(f"Guest image SHA-256: {guest_sha}\n")
+    out.write(f"EL2 binary SHA-256: {el2_sha}\n")
+    out.write(f"Commit: {commit}\n")
+    out.write(f"Branch: {branch}\n\n")
+    out.write("## Hardware Environment\n")
+    out.write("- TPM: swtpm unknown, PCR 16 extended: " + pcr_extended + "\n")
+    out.write("- SPDM: libspdm responder unknown, session reached ATTESTED: " + spdm_attested + "\n")
+    out.write("- SMMU: QEMU SMMUv3, MMIO base: 0x09050000, STE writes: " + str(ste_writes) + "\n")
+    out.write("- EL2 timer: /dev/iato-el2-timer, intervals fired: " + str(el2_intervals) + "\n\n")
+    out.write("## Test Results\n")
+    out.write(f"- Total: {counts['total']}\n")
+    out.write(f"- Passed: {counts['passed']}\n")
+    out.write(f"- Failed: {counts['failed']}\n")
+    out.write(f"- Skipped: {counts['skipped']}\n\n")
+    out.write("## Failed Tests\n")
+    out.write("None\n\n" if not failed_tests else "\n".join(failed_tests) + "\n\n")
+    out.write("## Verdict\n")
+    out.write(verdict + "\n")
+PY
+
+exit "${HW_EXIT}"


### PR DESCRIPTION
### Motivation
- Provide a single reproducible harness to boot the full IĀTŌ stack (swtpm, libspdm responder, SMMUv3, and EL2 hypervisor) so the existing `@pytest.mark.hw` hardware tests can be exercised end-to-end without manual setup.
- Ensure hardware code paths gated by `IATO_HW_MODE=1` are actually exercised in CI or by operators, and produce a structured, auditable test summary at `tests/hw-results.md`.

### Description
- Add `scripts/qemu-harness.sh` implementing preflight checks, ordered sidecar startup (`swtpm` then libspdm responder) with health checks, QEMU boot with SMMUv3/TPM/SPDM and virtio console, console-based guest orchestration to run `pytest -m hw`, artifact extraction via base64 streams, deterministic result parsing, and guaranteed cleanup via `trap EXIT` (PID/socket cleanup and teardown). 
- Add `scripts/build-guest-image.sh` to produce `build/guest/guest.img` from Ubuntu 24.04 arm64 minimal cloud image with checksum verification, offline wheel-based Python dependency install, repository payload injection to `/opt/iato`, and a `[guest-ready]` signal wired via `/etc/rc.local`.
- Add `scripts/fetch-wheels.sh` to download required aarch64 Python wheels into `build/guest/wheels/` for offline guest provisioning.
- Add `docs/qemu-harness.md` with operator setup and environment variable documentation, and extend `Makefile` with `fetch-wheels`, `build-guest-image`, `qemu-harness`, `hw-test`, and `check-full` targets and updated `.PHONY` entries.

### Testing
- Verified shell syntax for new scripts with `bash -n scripts/fetch-wheels.sh scripts/build-guest-image.sh scripts/qemu-harness.sh` which returned OK. 
- Marked new scripts executable (`chmod +x`) and performed a `make -n fetch-wheels build-guest-image qemu-harness hw-test check-full` dry-run to validate Makefile wiring and observed the expected `check-full` behavior that skips hardware test when `build/guest/guest.img` is absent. 
- Committed the changes successfully (`git commit`) and created the PR; no hardware QEMU runs were executed in this rollout (the harness assumes required binaries/images are pre-provisioned).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a5325d880832fb26988747161bc91)