### PR TITLE
EL2: SMMUv3 STRTAB init, SMC credential path, and CNTHP timer/expiry sweep

### DIFF
--- a/el2/cnthp_driver.c
+++ b/el2/cnthp_driver.c
@@ -1,0 +1,100 @@
+#include "cnthp_driver.h"
+
+#define IATO_GIC_PPI_CNTHP 26U
+
+static uint64_t iato_cnthp_freq_hz;
+static uint64_t iato_cnthp_interval_ns = 30ULL * 1000000000ULL;
+static uint64_t iato_cnthp_last_arm_cval;
+static iato_sweep_fn_t iato_cnthp_sweep_cb;
+static volatile int iato_cnthp_active;
+
+#ifdef IATO_MOCK_CNTVCT
+extern uint64_t iato_mock_cntfrq;
+extern uint64_t iato_mock_cntpct;
+extern uint64_t iato_mock_cnthp_tval;
+extern uint64_t iato_mock_cnthp_ctl;
+static inline uint64_t read_cntfrq(void) { return iato_mock_cntfrq; }
+static inline uint64_t read_cntpct(void) { return iato_mock_cntpct; }
+static inline void write_cnthp_tval(uint64_t v) { iato_mock_cnthp_tval = v; }
+static inline void write_cnthp_ctl(uint64_t v) { iato_mock_cnthp_ctl = v; }
+static inline uint64_t read_cnthp_ctl(void) { return iato_mock_cnthp_ctl; }
+#else
+static inline uint64_t read_cntfrq(void) { uint64_t v; __asm__ volatile("mrs %0, cntfrq_el0" : "=r"(v)); return v; }
+static inline uint64_t read_cntpct(void) { uint64_t v; __asm__ volatile("mrs %0, cntpct_el0" : "=r"(v)); return v; }
+static inline void write_cnthp_tval(uint64_t v) { __asm__ volatile("msr cnthp_tval_el2, %0" :: "r"(v)); }
+static inline void write_cnthp_ctl(uint64_t v) { __asm__ volatile("msr cnthp_ctl_el2, %0" :: "r"(v)); __asm__ volatile("isb"); }
+static inline uint64_t read_cnthp_ctl(void) { uint64_t v; __asm__ volatile("mrs %0, cnthp_ctl_el2" : "=r"(v)); return v; }
+#endif
+
+extern int iato_irq_register(uint32_t irq, void (*handler)(void));
+
+int iato_cnthp_init(void) {
+    iato_cnthp_freq_hz = read_cntfrq();
+    if ((iato_cnthp_freq_hz == 0ULL) || (iato_cnthp_freq_hz > 1000000000ULL)) {
+        return IATO_CNTHP_ERR_FREQ;
+    }
+    write_cnthp_ctl(0x2ULL);
+    if (iato_irq_register(IATO_GIC_PPI_CNTHP, iato_cnthp_irq_handler) != 0) {
+        return IATO_CNTHP_ERR_IRQ;
+    }
+    iato_cnthp_active = 0;
+    return IATO_CNTHP_OK;
+}
+
+void iato_cnthp_set_interval(uint64_t interval_ns) {
+    iato_cnthp_interval_ns = interval_ns;
+}
+
+void iato_cnthp_arm_ns(uint64_t interval_ns) {
+    uint64_t ticks;
+    if (interval_ns == 0ULL) {
+        iato_cnthp_disarm();
+        return;
+    }
+    ticks = (interval_ns * iato_cnthp_freq_hz) / 1000000000ULL;
+    iato_cnthp_last_arm_cval = read_cntpct();
+    write_cnthp_tval(ticks);
+    write_cnthp_ctl(0x1ULL);
+    iato_cnthp_active = 1;
+}
+
+void iato_cnthp_disarm(void) {
+    write_cnthp_ctl(0x2ULL);
+    iato_cnthp_active = 0;
+}
+
+uint64_t iato_cnthp_read_elapsed_ns(void) {
+    uint64_t delta = read_cntpct() - iato_cnthp_last_arm_cval;
+    if (iato_cnthp_freq_hz == 0ULL) {
+        return 0ULL;
+    }
+    return (delta * 1000000000ULL) / iato_cnthp_freq_hz;
+}
+
+void iato_cnthp_register_sweep(iato_sweep_fn_t callback) {
+    iato_cnthp_sweep_cb = callback;
+}
+
+void iato_cnthp_irq_handler(void) {
+    uint64_t ctl = read_cnthp_ctl();
+    uint64_t elapsed;
+    if ((ctl & (1ULL << 2U)) == 0ULL) {
+        return;
+    }
+    write_cnthp_ctl(0x2ULL);
+#ifdef IATO_MOCK_CNTVCT
+    iato_mock_cnthp_ctl &= ~(1ULL << 2U);
+#endif
+    elapsed = iato_cnthp_read_elapsed_ns();
+    if (iato_cnthp_sweep_cb != (iato_sweep_fn_t)0) {
+        iato_cnthp_sweep_cb(elapsed);
+    }
+    if ((iato_cnthp_active != 0) && (iato_cnthp_interval_ns != 0ULL)) {
+        iato_cnthp_arm_ns(iato_cnthp_interval_ns);
+    }
+}
+
+#ifdef IATO_HOST_TEST
+uint64_t iato_cnthp_test_read_ctl(void) { return read_cnthp_ctl(); }
+uint64_t iato_cnthp_test_read_tval(void) { return iato_mock_cnthp_tval; }
+#endif

--- a/el2/cnthp_driver.h
+++ b/el2/cnthp_driver.h
@@ -1,0 +1,25 @@
+#ifndef IATO_CNTHP_DRIVER_H
+#define IATO_CNTHP_DRIVER_H
+
+#include <stdint.h>
+
+#define IATO_CNTHP_OK       0
+#define IATO_CNTHP_ERR_FREQ -1
+#define IATO_CNTHP_ERR_IRQ  -2
+
+typedef void (*iato_sweep_fn_t)(uint64_t elapsed_ns);
+
+int iato_cnthp_init(void);
+void iato_cnthp_arm_ns(uint64_t interval_ns);
+void iato_cnthp_disarm(void);
+void iato_cnthp_irq_handler(void);
+void iato_cnthp_register_sweep(iato_sweep_fn_t callback);
+void iato_cnthp_set_interval(uint64_t interval_ns);
+uint64_t iato_cnthp_read_elapsed_ns(void);
+
+#ifdef IATO_HOST_TEST
+uint64_t iato_cnthp_test_read_ctl(void);
+uint64_t iato_cnthp_test_read_tval(void);
+#endif
+
+#endif

--- a/el2/cnthp_driver_test.c
+++ b/el2/cnthp_driver_test.c
@@ -1,0 +1,68 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "cnthp_driver.h"
+#include "expiry_sweep.h"
+
+#include "smmu_init.h"
+
+volatile uint8_t iato_mock_smmu_mmio[IATO_SMMU_SIZE];
+
+uint64_t iato_mock_cntfrq = 62500000ULL;
+uint64_t iato_mock_cntpct;
+uint64_t iato_mock_cnthp_tval;
+uint64_t iato_mock_cnthp_ctl;
+
+static void (*g_irq_handler)(void);
+static uint64_t g_wall;
+static uint64_t g_sweep_calls;
+static uint64_t g_last_elapsed;
+
+int iato_irq_register(uint32_t irq, void (*handler)(void)) {
+    (void)irq;
+    g_irq_handler = handler;
+    return 0;
+}
+
+uint64_t iato_wall_time_s(void) { return g_wall; }
+
+int iato_mock_smmu_fault_ste(uint32_t stream_id) {
+    (void)stream_id;
+    g_sweep_calls++;
+    return 0;
+}
+
+static void test_cb(uint64_t elapsed_ns) {
+    g_last_elapsed = elapsed_ns;
+}
+
+int main(void) {
+    int rc;
+    rc = iato_cnthp_init();
+    assert(rc == IATO_CNTHP_OK);
+
+    iato_cnthp_arm_ns(30000000000ULL);
+    assert(iato_cnthp_test_read_tval() == 1875000000ULL);
+    assert((iato_cnthp_test_read_ctl() & 0x1ULL) == 1ULL);
+
+    iato_cnthp_disarm();
+    assert(iato_cnthp_test_read_ctl() == 0x2ULL);
+
+    iato_cnthp_register_sweep(test_cb);
+    iato_cnthp_arm_ns(1000000000ULL);
+    iato_mock_cntpct += 62500000ULL;
+    iato_mock_cnthp_ctl |= (1ULL << 2U);
+    g_irq_handler();
+    assert(g_last_elapsed == 1000000000ULL);
+
+    iato_binding_table[1].stream_id = 1U;
+    iato_binding_table[1].status = IATO_STATUS_ACTIVE;
+    iato_binding_table[1].expiry_unix_s = 10U;
+    g_wall = 11U;
+    assert(iato_expiry_sweep(0ULL) == 1);
+    assert(g_sweep_calls == 1ULL);
+
+    puts("cnthp_driver_test: ok");
+    return 0;
+}

--- a/el2/cnthp_ioctl.c
+++ b/el2/cnthp_ioctl.c
@@ -1,0 +1,36 @@
+#include "cnthp_ioctl.h"
+
+extern int iato_wq_wait(void *wq);
+extern void iato_wq_wake(void *wq);
+
+static volatile uint32_t iato_timer_wq;
+
+int iato_cnthp_ioctl(uint32_t cmd, uint64_t arg) {
+    if (cmd == IATO_TIMER_ARM) {
+        if (arg == 0ULL) {
+            return -22;
+        }
+        iato_cnthp_set_interval(arg);
+        iato_cnthp_arm_ns(arg);
+        return 0;
+    }
+    if (cmd == IATO_TIMER_DISARM) {
+        iato_cnthp_disarm();
+        return 0;
+    }
+    return -22;
+}
+
+int iato_cnthp_read_elapsed(uint64_t *out_elapsed_ns) {
+    int rc;
+    rc = iato_wq_wait((void *)&iato_timer_wq);
+    if (rc != 0) {
+        return -4;
+    }
+    *out_elapsed_ns = iato_cnthp_read_elapsed_ns();
+    return 8;
+}
+
+void iato_cnthp_signal_irq(void) {
+    iato_wq_wake((void *)&iato_timer_wq);
+}

--- a/el2/cnthp_ioctl.h
+++ b/el2/cnthp_ioctl.h
@@ -1,0 +1,20 @@
+#ifndef IATO_CNTHP_IOCTL_H
+#define IATO_CNTHP_IOCTL_H
+
+#include <stdint.h>
+
+#include "cnthp_driver.h"
+
+#ifndef _IO
+#define _IO(type, nr) (((type) << 8) | (nr))
+#define _IOW(type, nr, data_type) (((type) << 8) | (nr) | 0x10000U)
+#endif
+
+#define IATO_TIMER_ARM    _IOW('A', 1, uint64_t)
+#define IATO_TIMER_DISARM _IO('A', 2)
+
+int iato_cnthp_ioctl(uint32_t cmd, uint64_t arg);
+int iato_cnthp_read_elapsed(uint64_t *out_elapsed_ns);
+void iato_cnthp_signal_irq(void);
+
+#endif

--- a/el2/expiry_sweep.c
+++ b/el2/expiry_sweep.c
@@ -1,0 +1,49 @@
+#include "expiry_sweep.h"
+
+extern uint64_t iato_wall_time_s(void);
+
+iato_binding_entry_t iato_binding_table[IATO_SMMU_MAX_STREAMS];
+static volatile uint32_t iato_binding_lock;
+
+static void lock_acquire(volatile uint32_t *l) {
+    while (__sync_lock_test_and_set(l, 1U) != 0U) {
+    }
+}
+
+static void lock_release(volatile uint32_t *l) {
+    __sync_lock_release(l);
+}
+
+int iato_expiry_sweep(uint64_t elapsed_ns) {
+    uint32_t to_fault[IATO_SMMU_MAX_STREAMS];
+    uint32_t n = 0U;
+    uint32_t i;
+    uint64_t now;
+    (void)elapsed_ns;
+
+    now = iato_wall_time_s();
+    lock_acquire(&iato_binding_lock);
+    for (i = 0U; i < IATO_SMMU_MAX_STREAMS; ++i) {
+        if ((iato_binding_table[i].status == IATO_STATUS_ACTIVE) &&
+            (iato_binding_table[i].expiry_unix_s <= now)) {
+            to_fault[n++] = iato_binding_table[i].stream_id;
+        }
+    }
+    lock_release(&iato_binding_lock);
+
+    for (i = 0U; i < n; ++i) {
+        #ifdef IATO_MOCK_SMMU
+        extern int iato_mock_smmu_fault_ste(uint32_t stream_id);
+        (void)iato_mock_smmu_fault_ste(to_fault[i]);
+#else
+        (void)iato_smmu_fault_ste(to_fault[i]);
+#endif
+    }
+
+    lock_acquire(&iato_binding_lock);
+    for (i = 0U; i < n; ++i) {
+        iato_binding_table[to_fault[i]].status = IATO_STATUS_AWAITING_POLICY;
+    }
+    lock_release(&iato_binding_lock);
+    return (int)n;
+}

--- a/el2/expiry_sweep.h
+++ b/el2/expiry_sweep.h
@@ -1,0 +1,22 @@
+#ifndef IATO_EXPIRY_SWEEP_H
+#define IATO_EXPIRY_SWEEP_H
+
+#include <stdint.h>
+
+#include "smmu_init.h"
+
+typedef struct {
+    uint32_t stream_id;
+    uint64_t spdm_session_id[2];
+    uint8_t status;
+    uint64_t expiry_unix_s;
+} iato_binding_entry_t;
+
+#define IATO_STATUS_AWAITING_POLICY 0U
+#define IATO_STATUS_ACTIVE 1U
+#define IATO_STATUS_REVOKED 2U
+
+extern iato_binding_entry_t iato_binding_table[IATO_SMMU_MAX_STREAMS];
+int iato_expiry_sweep(uint64_t elapsed_ns);
+
+#endif

--- a/el2/smc_handler.c
+++ b/el2/smc_handler.c
@@ -1,0 +1,162 @@
+#include "smc_handler.h"
+
+typedef struct {
+    uint32_t tokens;
+    uint64_t last_refill_ns;
+    uint8_t failure_count;
+    uint64_t penalty_until_ns;
+} iato_rate_state_t;
+
+static uint8_t iato_cred_staging[IATO_CRED_MAX_BYTES] __attribute__((aligned(8)));
+static iato_rate_state_t iato_rate[IATO_SMMU_MAX_STREAMS];
+
+extern int iato_py_validate_credential(const uint8_t *cred, size_t cred_len, uint32_t stream_id,
+                                       uint64_t *out_pa_base, uint64_t *out_pa_limit, uint8_t *out_permissions);
+
+#ifdef IATO_MOCK_CNTVCT
+extern uint64_t iato_mock_cntvct_now;
+static uint64_t iato_read_cntvct(void) { return iato_mock_cntvct_now; }
+#else
+static uint64_t iato_read_cntvct(void) {
+    uint64_t v;
+    __asm__ volatile("mrs %0, cntvct_el0" : "=r"(v));
+    return v;
+}
+#endif
+
+static void iato_staging_clear(void) {
+    size_t i;
+    for (i = 0U; i < IATO_CRED_MAX_BYTES; ++i) {
+        iato_cred_staging[i] = 0U;
+    }
+}
+
+static void rate_refill(iato_rate_state_t *s, uint64_t now) {
+    uint64_t elapsed = now - s->last_refill_ns;
+    uint32_t add = (uint32_t)(elapsed / 1000000000ULL);
+    if (add > 0U) {
+        uint32_t nt = s->tokens + add;
+        s->tokens = (nt > 5U) ? 5U : nt;
+        s->last_refill_ns = now;
+    }
+}
+
+static int rate_allow(uint32_t sid, uint64_t now) {
+    iato_rate_state_t *s = &iato_rate[sid];
+    rate_refill(s, now);
+    if (s->penalty_until_ns > now) {
+        return 0;
+    }
+    if (s->tokens == 0U) {
+        return 0;
+    }
+    s->tokens--;
+    return 1;
+}
+
+static void rate_failure(uint32_t sid, uint64_t now) {
+    iato_rate_state_t *s = &iato_rate[sid];
+    if (s->failure_count < 255U) {
+        s->failure_count++;
+    }
+    if (s->failure_count >= 3U) {
+        s->penalty_until_ns = now + 60000000000ULL;
+        s->failure_count = 0U;
+    }
+}
+
+static void rate_success(uint32_t sid) {
+    iato_rate[sid].failure_count = 0U;
+}
+
+int iato_smc_init(void) {
+    uint32_t i;
+    iato_staging_clear();
+    for (i = 0U; i < IATO_SMMU_MAX_STREAMS; ++i) {
+        iato_rate[i].tokens = 5U;
+        iato_rate[i].last_refill_ns = 0ULL;
+        iato_rate[i].failure_count = 0U;
+        iato_rate[i].penalty_until_ns = 0ULL;
+    }
+    return 0;
+}
+
+int iato_smc_copy_from_guest(void *dst, uint64_t guest_pa, size_t length) {
+    size_t i;
+    uint64_t end = guest_pa + (uint64_t)length;
+    volatile uint8_t *d = (volatile uint8_t *)dst;
+    if ((guest_pa < IATO_GUEST_RAM_BASE) || (end > (IATO_GUEST_RAM_BASE + IATO_GUEST_RAM_SIZE)) || (end < guest_pa)) {
+        return (int)IATO_SMC_ERR_GPA;
+    }
+#ifdef IATO_MOCK_VALIDATOR
+    extern uint8_t iato_mock_guest_ram[IATO_GUEST_RAM_SIZE];
+    volatile uint8_t *src = (volatile uint8_t *)&iato_mock_guest_ram[guest_pa - IATO_GUEST_RAM_BASE];
+#else
+    volatile uint8_t *src = (volatile uint8_t *)(uintptr_t)guest_pa;
+#endif
+    for (i = 0U; i < length; ++i) {
+        d[i] = src[i];
+    }
+    return 0;
+}
+
+uint64_t iato_smc_handle(uint64_t regs[4]) {
+    uint32_t sid;
+    uint64_t len;
+    uint64_t gpa;
+    uint64_t pa_base = 0ULL;
+    uint64_t pa_limit = 0ULL;
+    uint8_t perms = 0U;
+    int rc;
+    uint64_t now;
+
+    if (regs[0] != IATO_SMC_FUNCTION_ID) {
+        return IATO_SMC_ERR_INTERNAL;
+    }
+    sid = (uint32_t)regs[3];
+    if (sid >= IATO_SMMU_MAX_STREAMS) {
+        return IATO_SMC_ERR_STREAM;
+    }
+    now = iato_read_cntvct();
+    if (!rate_allow(sid, now)) {
+        return IATO_SMC_ERR_RATE;
+    }
+
+    len = regs[2];
+    if ((len != IATO_CRED_MIN_BYTES) && (len != IATO_CRED_MAX_BYTES)) {
+        rate_failure(sid, now);
+        iato_staging_clear();
+        return IATO_SMC_ERR_LENGTH;
+    }
+    gpa = regs[1];
+    rc = iato_smc_copy_from_guest(iato_cred_staging, gpa, (size_t)len);
+    if (rc != 0) {
+        rate_failure(sid, now);
+        iato_staging_clear();
+        return IATO_SMC_ERR_GPA;
+    }
+
+    rc = iato_py_validate_credential(iato_cred_staging, (size_t)len, sid, &pa_base, &pa_limit, &perms);
+    if (rc != 0) {
+        rate_failure(sid, now);
+        iato_staging_clear();
+        return IATO_SMC_ERR_VALIDATION;
+    }
+
+    rc = iato_smmu_write_ste(sid, pa_base, pa_limit, perms);
+    if (rc != IATO_SMMU_OK) {
+        rate_failure(sid, now);
+        iato_staging_clear();
+        return IATO_SMC_ERR_SMMU;
+    }
+
+    rate_success(sid);
+    iato_staging_clear();
+    return IATO_SMC_OK;
+}
+
+#ifdef IATO_HOST_TEST
+const uint8_t *iato_smc_staging_ptr(void) {
+    return &iato_cred_staging[0];
+}
+#endif

--- a/el2/smc_handler.h
+++ b/el2/smc_handler.h
@@ -1,0 +1,32 @@
+#ifndef IATO_SMC_HANDLER_H
+#define IATO_SMC_HANDLER_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "smmu_init.h"
+
+#define IATO_SMC_FUNCTION_ID    0x82000001UL
+#define IATO_SMC_OK             0x00000000UL
+#define IATO_SMC_ERR_LENGTH     0x00000001UL
+#define IATO_SMC_ERR_GPA        0x00000002UL
+#define IATO_SMC_ERR_STREAM     0x00000003UL
+#define IATO_SMC_ERR_VALIDATION 0x00000004UL
+#define IATO_SMC_ERR_SMMU       0x00000005UL
+#define IATO_SMC_ERR_RATE       0x00000006UL
+#define IATO_SMC_ERR_INTERNAL   0xFFFFFFFFUL
+
+#define IATO_CRED_MAX_BYTES     149U
+#define IATO_CRED_MIN_BYTES     109U
+#define IATO_GUEST_RAM_BASE     0x40000000ULL
+#define IATO_GUEST_RAM_SIZE     0x04000000ULL
+
+int iato_smc_init(void);
+uint64_t iato_smc_handle(uint64_t regs[4]);
+int iato_smc_copy_from_guest(void *dst, uint64_t guest_pa, size_t length);
+
+#ifdef IATO_HOST_TEST
+const uint8_t *iato_smc_staging_ptr(void);
+#endif
+
+#endif

--- a/el2/smc_handler_test.c
+++ b/el2/smc_handler_test.c
@@ -1,0 +1,91 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "smc_handler.h"
+#include "smmu_init.h"
+
+volatile uint8_t iato_mock_smmu_mmio[IATO_SMMU_SIZE];
+uint8_t iato_mock_guest_ram[IATO_GUEST_RAM_SIZE];
+uint64_t iato_mock_cntvct_now;
+
+static int g_validator_rc;
+static uint64_t g_pa_base = 0x100000ULL;
+static uint64_t g_pa_limit = 0x200000ULL;
+static uint8_t g_perms = 3U;
+
+int iato_py_validate_credential(const uint8_t *cred, size_t cred_len, uint32_t stream_id,
+                                uint64_t *out_pa_base, uint64_t *out_pa_limit, uint8_t *out_permissions) {
+    (void)cred;
+    (void)cred_len;
+    (void)stream_id;
+    *out_pa_base = g_pa_base;
+    *out_pa_limit = g_pa_limit;
+    *out_permissions = g_perms;
+    return g_validator_rc;
+}
+
+static void fill_guest(uint64_t gpa, size_t n, uint8_t seed) {
+    size_t i;
+    uint64_t off = gpa - IATO_GUEST_RAM_BASE;
+    for (i = 0; i < n; ++i) {
+        iato_mock_guest_ram[off + i] = (uint8_t)(seed + (uint8_t)i);
+    }
+}
+
+int main(void) {
+    uint64_t regs[4] = {IATO_SMC_FUNCTION_ID, IATO_GUEST_RAM_BASE, IATO_CRED_MIN_BYTES, 0};
+    const uint8_t *staging;
+    size_t i;
+
+    *(volatile uint32_t *)((uintptr_t)&iato_mock_smmu_mmio[0] + IATO_SMMU_REG_IDR0) = 1U;
+    *(volatile uint32_t *)((uintptr_t)&iato_mock_smmu_mmio[0] + IATO_SMMU_REG_IDR1) = 1U;
+    assert(iato_smmu_init() == IATO_SMMU_OK);
+    assert(iato_smc_init() == 0);
+
+    fill_guest(IATO_GUEST_RAM_BASE, IATO_CRED_MIN_BYTES, 0x10U);
+    g_validator_rc = 0;
+    g_pa_base = 0x100000ULL;
+    g_pa_limit = 0x200000ULL;
+    assert(iato_smc_handle(regs) == IATO_SMC_OK);
+
+    regs[2] = 120U;
+    assert(iato_smc_handle(regs) == IATO_SMC_ERR_LENGTH);
+    regs[2] = IATO_CRED_MIN_BYTES;
+
+    regs[1] = IATO_GUEST_RAM_BASE + IATO_GUEST_RAM_SIZE;
+    assert(iato_smc_handle(regs) == IATO_SMC_ERR_GPA);
+    regs[1] = IATO_GUEST_RAM_BASE;
+
+    regs[3] = 64U;
+    assert(iato_smc_handle(regs) == IATO_SMC_ERR_STREAM);
+    regs[3] = 0U;
+
+    g_validator_rc = 1;
+    assert(iato_smc_handle(regs) == IATO_SMC_ERR_VALIDATION);
+    staging = iato_smc_staging_ptr();
+    for (i = 0; i < IATO_CRED_MAX_BYTES; ++i) {
+        assert(staging[i] == 0U);
+    }
+
+    assert(iato_smc_init() == 0);
+    g_validator_rc = 0;
+    g_pa_base = 0x100001ULL;
+    g_pa_limit = 0x200000ULL;
+    assert(iato_smc_handle(regs) == IATO_SMC_ERR_SMMU);
+
+    assert(iato_smc_init() == 0);
+    g_pa_base = 0x300000ULL;
+    g_pa_limit = 0x400000ULL;
+    fill_guest(IATO_GUEST_RAM_BASE, IATO_CRED_MIN_BYTES, 0x44U);
+    assert(iato_smc_handle(regs) == IATO_SMC_OK);
+
+    iato_mock_cntvct_now = 0ULL;
+    for (i = 0; i < 4; ++i) {
+        assert(iato_smc_handle(regs) == IATO_SMC_OK);
+    }
+    assert(iato_smc_handle(regs) == IATO_SMC_ERR_RATE);
+
+    puts("smc_handler_test: ok");
+    return 0;
+}

--- a/el2/smmu_init.c
+++ b/el2/smmu_init.c
@@ -1,0 +1,186 @@
+#include "smmu_init.h"
+
+#define IATO_TIMEOUT_ITERS 1000U
+#define IATO_CMDQ_ENTRIES 256U
+
+#ifdef IATO_MOCK_MMIO
+extern volatile uint8_t iato_mock_smmu_mmio[IATO_SMMU_SIZE];
+#define IATO_MMIO_BASE_PTR ((uintptr_t)&iato_mock_smmu_mmio[0])
+#else
+#define IATO_MMIO_BASE_PTR ((uintptr_t)IATO_SMMU_BASE)
+#endif
+
+#if defined(__aarch64__)
+#define IATO_DSB_SY() __asm__ volatile("dsb sy" ::: "memory")
+#define IATO_ISB() __asm__ volatile("isb" ::: "memory")
+#else
+#define IATO_DSB_SY() do {} while (0)
+#define IATO_ISB() do {} while (0)
+#endif
+
+static volatile uint64_t iato_smmu_strtab[IATO_SMMU_MAX_STREAMS][IATO_STE_SIZE_WORDS]
+    __attribute__((aligned(IATO_STE_SIZE_BYTES)));
+
+static volatile uint64_t iato_smmu_cmdq[IATO_CMDQ_ENTRIES][2]
+    __attribute__((aligned(128)));
+
+static int iato_smmu_initialized;
+
+static inline volatile uint32_t *reg32(uint32_t off) {
+    return (volatile uint32_t *)(IATO_MMIO_BASE_PTR + (uintptr_t)off);
+}
+
+static inline volatile uint64_t *reg64(uint32_t off) {
+    return (volatile uint64_t *)(IATO_MMIO_BASE_PTR + (uintptr_t)off);
+}
+
+static uint32_t ilog2_u64(uint64_t v) {
+    uint32_t r = 0U;
+    while (v > 1U) {
+        v >>= 1U;
+        r++;
+    }
+    return r;
+}
+
+static int poll_cr0ack(uint32_t target) {
+    uint32_t i;
+    for (i = 0U; i < IATO_TIMEOUT_ITERS; ++i) {
+        if ((*reg32(IATO_SMMU_REG_CR0ACK) & 0x1U) == (target & 0x1U)) {
+            return IATO_SMMU_OK;
+        }
+#ifdef IATO_MOCK_MMIO
+        *reg32(IATO_SMMU_REG_CR0ACK) = target;
+#endif
+    }
+    return IATO_SMMU_ERR_TIMEOUT;
+}
+
+static int cmdq_issue(uint64_t cmd0, uint64_t cmd1, int wait_sync) {
+    uint32_t prod = *reg32(IATO_SMMU_REG_CMDQ_PROD);
+    uint32_t idx = prod & (IATO_CMDQ_ENTRIES - 1U);
+    iato_smmu_cmdq[idx][0] = cmd0;
+    iato_smmu_cmdq[idx][1] = cmd1;
+    prod++;
+    *reg32(IATO_SMMU_REG_CMDQ_PROD) = prod;
+#ifdef IATO_MOCK_MMIO
+    *reg32(IATO_SMMU_REG_CMDQ_CONS) = prod;
+#endif
+    if (wait_sync != 0) {
+        uint32_t i;
+        for (i = 0U; i < IATO_TIMEOUT_ITERS; ++i) {
+            if (*reg32(IATO_SMMU_REG_CMDQ_CONS) == prod) {
+                return IATO_SMMU_OK;
+            }
+        }
+        return IATO_SMMU_ERR_TIMEOUT;
+    }
+    return IATO_SMMU_OK;
+}
+
+int iato_smmu_init(void) {
+    uint32_t i;
+    uint32_t idr0 = *reg32(IATO_SMMU_REG_IDR0);
+    uint32_t idr1 = *reg32(IATO_SMMU_REG_IDR1);
+
+    if (iato_smmu_initialized != 0) {
+        return IATO_SMMU_OK;
+    }
+    if ((idr0 == 0U) && (idr1 == 0U)) {
+        return IATO_SMMU_ERR_IDR;
+    }
+    *reg32(IATO_SMMU_REG_CR0) = 0U;
+    if (poll_cr0ack(0U) != IATO_SMMU_OK) {
+        return IATO_SMMU_ERR_TIMEOUT;
+    }
+
+    for (i = 0U; i < IATO_SMMU_MAX_STREAMS; ++i) {
+        uint32_t w;
+        for (w = 0U; w < IATO_STE_SIZE_WORDS; ++w) {
+            iato_smmu_strtab[i][w] = 0ULL;
+        }
+    }
+    IATO_DSB_SY();
+
+    if ((((uintptr_t)&iato_smmu_strtab[0][0]) & (IATO_STE_SIZE_BYTES - 1U)) != 0U) {
+        return IATO_SMMU_ERR_STRTAB;
+    }
+
+    *reg64(IATO_SMMU_REG_STRTAB_BASE) = (uint64_t)(uintptr_t)&iato_smmu_strtab[0][0];
+    *reg32(IATO_SMMU_REG_STRTAB_BASE_CFG) = ilog2_u64(IATO_SMMU_MAX_STREAMS);
+    *reg64(IATO_SMMU_REG_CMDQ_BASE) = (uint64_t)(uintptr_t)&iato_smmu_cmdq[0][0];
+    *reg32(IATO_SMMU_REG_CMDQ_PROD) = 0U;
+    *reg32(IATO_SMMU_REG_CMDQ_CONS) = 0U;
+
+    *reg32(IATO_SMMU_REG_CR0) = 1U;
+    if (poll_cr0ack(1U) != IATO_SMMU_OK) {
+        return IATO_SMMU_ERR_TIMEOUT;
+    }
+    IATO_DSB_SY();
+    IATO_ISB();
+    iato_smmu_initialized = 1;
+    return IATO_SMMU_OK;
+}
+
+int iato_smmu_write_ste(uint32_t stream_id, uint64_t pa_base, uint64_t pa_limit, uint8_t permissions) {
+    uint64_t range;
+    uint64_t word0;
+    uint64_t word2;
+    int rc;
+    if ((stream_id >= IATO_SMMU_MAX_STREAMS) || ((pa_base & 0xFFFULL) != 0ULL) || ((pa_limit & 0xFFFULL) != 0ULL) || (pa_limit <= pa_base)) {
+        return IATO_SMMU_ERR_RANGE;
+    }
+    range = pa_limit - pa_base;
+    word0 = 1ULL | (4ULL << 1U) | (((uint64_t)(permissions & 0x3U)) << 6U);
+    word2 = (1ULL << 10U) | (uint64_t)(64U - ilog2_u64(range));
+
+    iato_smmu_strtab[stream_id][0] = word0;
+    iato_smmu_strtab[stream_id][1] = 0ULL;
+    iato_smmu_strtab[stream_id][2] = word2;
+    iato_smmu_strtab[stream_id][3] = pa_base >> 12U;
+    iato_smmu_strtab[stream_id][4] = 0ULL;
+    iato_smmu_strtab[stream_id][5] = 0ULL;
+    iato_smmu_strtab[stream_id][6] = 0ULL;
+    iato_smmu_strtab[stream_id][7] = 0ULL;
+
+    rc = cmdq_issue(0x1ULL, (uint64_t)stream_id, 0);
+    if (rc != IATO_SMMU_OK) {
+        return rc;
+    }
+    rc = cmdq_issue(0x2ULL, 0ULL, 1);
+    if (rc != IATO_SMMU_OK) {
+        return rc;
+    }
+    IATO_DSB_SY();
+    IATO_ISB();
+    return IATO_SMMU_OK;
+}
+
+int iato_smmu_fault_ste(uint32_t stream_id) {
+    uint32_t w;
+    int rc;
+    if (stream_id >= IATO_SMMU_MAX_STREAMS) {
+        return IATO_SMMU_ERR_RANGE;
+    }
+    for (w = 0U; w < IATO_STE_SIZE_WORDS; ++w) {
+        iato_smmu_strtab[stream_id][w] = 0ULL;
+    }
+    rc = cmdq_issue(0x1ULL, (uint64_t)stream_id, 0);
+    if (rc != IATO_SMMU_OK) {
+        return rc;
+    }
+    rc = cmdq_issue(0x2ULL, 0ULL, 1);
+    if (rc != IATO_SMMU_OK) {
+        return rc;
+    }
+    IATO_DSB_SY();
+    IATO_ISB();
+    return IATO_SMMU_OK;
+}
+
+uint64_t iato_smmu_read_ste_word0(uint32_t stream_id) {
+    if (stream_id >= IATO_SMMU_MAX_STREAMS) {
+        return 0ULL;
+    }
+    return iato_smmu_strtab[stream_id][0];
+}

--- a/el2/smmu_init.h
+++ b/el2/smmu_init.h
@@ -1,0 +1,34 @@
+#ifndef IATO_SMMU_INIT_H
+#define IATO_SMMU_INIT_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define IATO_SMMU_BASE          0x09050000UL
+#define IATO_SMMU_SIZE          0x00010000UL
+#define IATO_SMMU_MAX_STREAMS   64U
+#define IATO_STE_SIZE_BYTES     64U
+#define IATO_STE_SIZE_WORDS     8U
+
+#define IATO_SMMU_OK            0
+#define IATO_SMMU_ERR_IDR       -1
+#define IATO_SMMU_ERR_TIMEOUT   -2
+#define IATO_SMMU_ERR_STRTAB    -3
+#define IATO_SMMU_ERR_RANGE     -4
+
+#define IATO_SMMU_REG_IDR0            0x0000U
+#define IATO_SMMU_REG_IDR1            0x0004U
+#define IATO_SMMU_REG_CR0             0x0020U
+#define IATO_SMMU_REG_CR0ACK          0x0024U
+#define IATO_SMMU_REG_STRTAB_BASE     0x0080U
+#define IATO_SMMU_REG_STRTAB_BASE_CFG 0x0088U
+#define IATO_SMMU_REG_CMDQ_BASE       0x0090U
+#define IATO_SMMU_REG_CMDQ_PROD       0x0098U
+#define IATO_SMMU_REG_CMDQ_CONS       0x009CU
+
+int iato_smmu_init(void);
+int iato_smmu_write_ste(uint32_t stream_id, uint64_t pa_base, uint64_t pa_limit, uint8_t permissions);
+int iato_smmu_fault_ste(uint32_t stream_id);
+uint64_t iato_smmu_read_ste_word0(uint32_t stream_id);
+
+#endif

--- a/el2/smmu_init_test.c
+++ b/el2/smmu_init_test.c
@@ -1,0 +1,55 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "smmu_init.h"
+
+volatile uint8_t iato_mock_smmu_mmio[IATO_SMMU_SIZE];
+
+static uint32_t mmio32(uint32_t off) {
+    return *(volatile uint32_t *)((uintptr_t)&iato_mock_smmu_mmio[0] + off);
+}
+
+int main(void) {
+    int rc;
+    uint32_t i;
+
+    *(volatile uint32_t *)((uintptr_t)&iato_mock_smmu_mmio[0] + IATO_SMMU_REG_IDR0) = 1U;
+    *(volatile uint32_t *)((uintptr_t)&iato_mock_smmu_mmio[0] + IATO_SMMU_REG_IDR1) = 1U;
+
+    rc = iato_smmu_init();
+    assert(rc == IATO_SMMU_OK);
+    for (i = 0; i < IATO_SMMU_MAX_STREAMS; ++i) {
+        assert(iato_smmu_read_ste_word0(i) == 0ULL);
+    }
+    assert((mmio32(IATO_SMMU_REG_CR0) & 1U) == 1U);
+
+    rc = iato_smmu_write_ste(1U, 0x100000ULL, 0x200000ULL, 3U);
+    assert(rc == IATO_SMMU_OK);
+    assert((iato_smmu_read_ste_word0(1U) & 1ULL) == 1ULL);
+    rc = iato_smmu_write_ste(64U, 0x100000ULL, 0x200000ULL, 3U);
+    assert(rc == IATO_SMMU_ERR_RANGE);
+    rc = iato_smmu_write_ste(2U, 0x100001ULL, 0x200000ULL, 3U);
+    assert(rc == IATO_SMMU_ERR_RANGE);
+
+    rc = iato_smmu_fault_ste(1U);
+    assert(rc == IATO_SMMU_OK);
+    assert(iato_smmu_read_ste_word0(1U) == 0ULL);
+    for (i = 0; i < IATO_SMMU_MAX_STREAMS; ++i) {
+        if (i != 1U) {
+            assert(iato_smmu_read_ste_word0(i) == 0ULL);
+        }
+    }
+
+    rc = iato_smmu_write_ste(3U, 0x400000ULL, 0x800000ULL, 1U);
+    assert(rc == IATO_SMMU_OK);
+    assert(iato_smmu_read_ste_word0(3U) != 0ULL);
+    assert(mmio32(IATO_SMMU_REG_CMDQ_PROD) == 6U);
+
+    rc = iato_smmu_init();
+    assert(rc == IATO_SMMU_OK);
+    assert(iato_smmu_read_ste_word0(3U) != 0ULL);
+
+    puts("smmu_init_test: ok");
+    return 0;
+}


### PR DESCRIPTION
### Motivation

- Ensure the SMMUv3 stream table is deterministically initialised to a safe (FAULT/ABORT) state at EL2 before any guest DMA is possible to satisfy I-01 hardware assumptions.
- Provide a single trusted SMC entrypoint that safely stages guest credential blobs, applies rate-limiting and validation, and programs STEs only after successful validation.
- Replace the Python timer backend with an EL2-resident CNTHP driver so expiry sweeps run independently of guest execution and can drive revocation reliably.

### Description

- Added SMMU initialization API in `el2/smmu_init.h` and implementation in `el2/smmu_init.c` that: performs IDR sanity checks, disables SMMU (`CR0=0`), zeroes the static `iato_smmu_strtab` (64 streams × 64 bytes), programs `STRTAB_BASE`/`STRTAB_BASE_CFG`/`CMDQ_BASE`, sets up a static 256-entry command queue, re-enables SMMU (`CR0.SMMUEN=1`), and exposes `iato_smmu_write_ste()`, `iato_smmu_fault_ste()` and `iato_smmu_read_ste_word0()` using volatile MMIO and bounded timeouts; host test hooks via `IATO_MOCK_MMIO` are included.
- Implemented the EL2 SMC handler in `el2/smc_handler.h/.c` that: declares an EL2 staging buffer, copies credential bytes from guest PA using explicit volatile reads, enforces per-StreamID token-based rate limiting and penalty logic, invokes the external `iato_py_validate_credential()` validator, securely zeroes staging on all non-OK paths, and calls `iato_smmu_write_ste()` on successful validation.
- Implemented CNTHP timer driver and ioctl glue: `el2/cnthp_driver.h/.c` provide `iato_cnthp_init()`, arm/disarm, IRQ handler (spurious check, disarm, call sweep callback, auto-rearm), interval control and elapsed readback; `el2/cnthp_ioctl.h/.c` expose a minimal ioctl/read interface and a wait-queue wake/sleep bridge for userspace blocking reads.
- Added expiry sweep logic in `el2/expiry_sweep.h/.c` that iterates the fixed-size `iato_binding_table`, collects expired ACTIVE stream IDs while holding a spinlock, releases the lock to call `iato_smmu_fault_ste()` for each, then reacquires the lock to update statuses (bounded loops, no dynamic allocation).
- Added host-side unit tests for each component: `el2/smmu_init_test.c`, `el2/smc_handler_test.c`, and `el2/cnthp_driver_test.c` using `IATO_MOCK_*` build-time hooks and mock MMIO/validator/CNTVCT where required.
- Updated `Makefile` with EL2 toolchain flags and new targets: `build-el2-smmu`, `test-el2-smmu`, `build-el2-smc`, `test-el2-smc`, `build-el2-cnthp`, `test-el2-cnthp`, plus aggregate `build-el2` and `test-el2` targets.

### Testing

- Ran unit tests for each component using the provided host mocks: `make test-el2-smmu`, `make test-el2-smc`, and `make test-el2-cnthp`, and then `make test-el2` to run the full EL2 test set.
- All automated EL2 unit tests completed successfully in the current environment (each `test-el2-*` target returned OK and `test-el2` reported all EL2 unit tests passed).
- Tests exercise mock MMIO, mock validator, and mock CNTVCT paths via `-DIATO_MOCK_MMIO`, `-DIATO_MOCK_VALIDATOR`, and `-DIATO_MOCK_CNTVCT` to validate control flow, rate-limiting, STE programming, CMDQ behaviour, timer arm/disarm, IRQ handling and expiry sweep lock discipline.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a5a3c0400832fb13d1fe22863e8ef)