### PR TITLE
Add explicit /tmp/iato-swtpm/swtpm.sock path to hardware result artifacts

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,80 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python Debugger: Current File",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${file}",
+      "console": "integratedTerminal"
+    },
+    {
+      "name": "IĀTŌ EL2 (QEMU GDB)",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/build/el2/iato-el2.bin",
+      "args": [],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}",
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "gdb",
+      "miDebuggerServerAddress": "localhost:1234",
+      "miDebuggerPath": "aarch64-none-elf-gdb",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        },
+        {
+          "description": "Set architecture to AArch64",
+          "text": "set architecture aarch64",
+          "ignoreFailures": false
+        },
+        {
+          "description": "Set remote hardware breakpoint limit",
+          "text": "set remote hardware-breakpoint-limit 4",
+          "ignoreFailures": false
+        }
+      ]
+    },
+    {
+      "name": "Python Debugger: Python File",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${file}"
+    }
+    ,
+    {
+      "name": "IĀTŌ EL2 (QEMU GDB, stop at connect)",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/build/el2/iato-el2.bin",
+      "args": [],
+      "stopAtEntry": false,
+      "stopAtConnect": true,
+      "cwd": "${workspaceFolder}",
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "gdb",
+      "miDebuggerServerAddress": "localhost:1234",
+      "miDebuggerPath": "aarch64-none-elf-gdb",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing and apply EL2 remote defaults",
+          "text": "-enable-pretty-printing\nset architecture aarch64\nset remote hardware-breakpoint-limit 4",
+          "ignoreFailures": false
+        },
+        {
+          "description": "Optional SVE register probe",
+          "text": "info registers sve",
+          "ignoreFailures": true
+        }
+      ]
+    }
+  ]
+}

--- a/docs.md
+++ b/docs.md
@@ -1,0 +1,173 @@
+---
+
+## Getting Started — Why It Won't Just Run in VS Code
+
+If you cloned this repository and pressed Run, nothing visible happened. This is expected. Here is why and what to do instead.
+
+---
+
+### 1. Architecture mismatch
+
+Your development machine is almost certainly x86-64 (Windows PC or Intel Mac). IĀTŌ-V7 is compiled for ARMv9-A targeting EL2 with SVE2. These are not compatible instruction sets. Your CPU cannot execute the kernel binary directly any more than it can run code compiled for a toaster.
+
+VS Code is a text editor. It has no knowledge of ARM exception levels, SMMUv3 stream tables, or EL2 privilege. Pressing the green Run button sends your x86 OS looking for an executable it cannot run.
+
+The fix is QEMU. `scripts/qemu-harness.sh` launches a software-emulated ARM CPU that supports the specific SMMUv3, EL2, and TPM features the kernel requires. Everything runs inside that virtual chip. Your host OS is irrelevant once the harness is running.
+
+---
+
+### 2. The EL2 privilege wall
+
+Standard debuggers — including every VS Code debug adapter — are designed for one of two contexts: user-mode (EL0) or kernel-mode (EL1). IĀTŌ-V7 is a hypervisor. It runs at EL2, which is a higher privilege level than any standard OS kernel. No off-the-shelf debugger has a concept of EL2.
+
+If you attach a standard debugger to the QEMU process without the correct configuration, the kernel appears dead. There is no process to attach to, no symbols loaded in a recognisable format, and no stack frames that make sense to a user-mode debug adapter.
+
+To debug IĀTŌ-V7 properly you must connect VS Code to the QEMU GDB stub. QEMU exposes a GDB remote protocol server that speaks at the machine level and can see EL2 registers. This requires a `launch.json` configured as follows:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "IĀTŌ EL2 (QEMU GDB)",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/build/el2/iato-el2.bin",
+      "miDebuggerServerAddress": "localhost:1234",
+      "miDebuggerPath": "aarch64-none-elf-gdb",
+      "setupCommands": [
+        {
+          "text": "set architecture aarch64",
+          "ignoreFailures": false
+        },
+        {
+          "text": "set remote hardware-breakpoint-limit 4",
+          "ignoreFailures": false
+        }
+      ],
+      "stopAtConnect": true,
+      "cwd": "${workspaceFolder}"
+    }
+  ]
+}
+```
+
+Start QEMU with the GDB stub enabled by adding `-s -S` to the QEMU flags in `scripts/qemu-harness.sh` before launching. Then attach VS Code. Without this exact configuration VS Code will report that the target is not responding because it is looking for an EL0 or EL1 process that does not exist.
+
+---
+
+### 3. Missing hardware dependencies
+
+The kernel has two hard external dependencies that must be running before it boots. If either is absent the boot sequence hangs at a specific point with no visible error unless you are watching the UART output.
+
+**`/tmp/iato-spdm.sock` — libspdm responder**
+
+The Python validator checks SPDM session binding as part of Invariant I-02. This check happens during the first credential validation after boot. If the libspdm responder process is not running and listening on this socket, `SpdmQemuTransport` will time out during `connect()`, the validator will return `IATO_PY_ERR_CALL`, and the SMC handler will return `IATO_SMC_ERR_VALIDATION` for every credential. The guest will be unable to provision any stream and the boot sequence will appear to complete normally but every DMA-capable device will remain in ABORT state permanently.
+
+`scripts/qemu-harness.sh` starts the libspdm responder before QEMU boots and health-checks the socket before proceeding. If you are starting components manually, start the responder first:
+
+```bash
+./scripts/start-spdm-responder.sh
+```
+
+Equivalent raw command:
+
+```bash
+./build/libspdm/bin/spdm_responder_emu \
+  --trans socket \
+  --socket-path /tmp/iato-spdm.sock
+```
+
+**`swtpm` — TPM emulator**
+
+`iato_py_embed_init()` calls `KeyCeremony.verify()` which calls `TpmEnrollmentSeal.verify_enrollment_unchanged()` which reads PCR 16 via the TPM device. If swtpm is not running, the TPM device handle fails to open, `iato_py_embed_init()` returns `IATO_PY_ERR_INIT`, and `iato_main()` prints `[iato][fatal] py_embed_init failed` to the UART and spins in an infinite loop. The kernel is alive but permanently halted. From VS Code this looks identical to a crash.
+
+`scripts/qemu-harness.sh` starts swtpm before QEMU and health-checks `/tmp/iato-swtpm/swtpm.sock` before proceeding. If you are starting manually:
+
+```bash
+./scripts/start-swtpm.sh
+```
+
+Equivalent raw command:
+
+```bash
+mkdir -p /tmp/iato-swtpm
+swtpm socket \
+  --tpmstate dir=/tmp/iato-swtpm \
+  --ctrl type=unixio,path=/tmp/iato-swtpm/swtpm.sock \
+  --tpm2 --daemon \
+  --pid /tmp/iato-swtpm/swtpm.pid
+```
+
+---
+
+### 4. The SVE2 register gap
+
+IĀTŌ-V7 uses SVE2 vector registers for initial state handling in `boot.S`. The standard VS Code Variables panel shows general-purpose registers x0–x30 and a stack view. It does not show SVE2 registers (Z0–Z31, P0–P15, FFR) unless you have installed the ARM Embedded Development extension pack and configured the register map explicitly.
+
+If you open the Variables panel during a debug session and see nothing meaningful, this is why. The telemetry you are looking for may be sitting in Z16 or a predicate register rather than in a named variable or a general-purpose register.
+
+To see SVE2 state in the GDB console during a debug session:
+
+```
+(gdb) info registers sve
+(gdb) p/x $z16
+(gdb) p/x $p0
+```
+
+The ARM Embedded Development extension for VS Code can surface these in the Registers panel if configured with the Cortex-A57 or Cortex-A72 register map, though SVE2 support in the extension is incomplete as of early 2026. The GDB console is the reliable path.
+
+---
+
+### The correct path to seeing it work
+
+Do not use the VS Code Run button. Use the terminal.
+
+**Step 1 — Launch the full hardware stack**
+
+```bash
+./scripts/run-hw-harness.sh
+```
+
+This wrapper sets metadata defaults (`IATO_OPERATOR`, `IATO_PRNG_SEED`) and then runs `scripts/qemu-harness.sh`.
+
+```bash
+# Optional: override metadata explicitly
+IATO_OPERATOR="alice" IATO_PRNG_SEED="0x4941544f2d5637" ./scripts/run-hw-harness.sh
+```
+
+This starts swtpm, starts the libspdm responder, boots QEMU with SMMUv3 and TPM attached, waits for the guest ready signal, and runs the test suite. It handles the startup order and health checks automatically.
+
+**Step 2 — Watch the UART**
+
+The kernel writes all diagnostic output to the PL011 UART at `0x09000000`. QEMU maps this to its stdout by default when `-nographic` is set in the harness. You will see the boot sequence:
+
+```
+[iato] EL2 hypervisor starting
+[iato] smmu_init OK
+[iato] smc_init OK
+[iato] cnthp_init OK
+[iato] py_embed_init OK
+[iato] EL2 hypervisor ready
+[guest-ready]
+```
+
+If any of these lines is absent or followed by `[iato][fatal]`, the line tells you exactly which subsystem failed. Check the corresponding sidecar process log (`/tmp/iato-swtpm/` or `/tmp/iato-spdm.log`) for the root cause.
+
+**Step 3 — Read the results**
+
+```bash
+cat tests/hw-results.md
+```
+
+This file is written by the harness after the test run completes. It contains the full pass/fail breakdown, hardware environment state (PCR 16 extended, SPDM session reached ATTESTED, SMMU STE write count, CNTHP intervals fired), and the git SHA for the run.
+
+For detailed event-level inspection of what happened during a specific test:
+
+```bash
+python3 scripts/hw-journal-inspect.py \
+  build/hw-journal/*.ndjson \
+  --format timeline
+```
+
+This renders all hardware events (TPM, SPDM, SMMU, CNTHP) in causal order so you can see exactly what the kernel was doing at the moment any test passed or failed.

--- a/scripts/batch_runner.py
+++ b/scripts/batch_runner.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Deterministic batch runner for timing-window compliance checks.
+
+By default this executes 4 batches x 100 runs in simulation mode to verify that
+all timing-mitigation-wrapped scripts report audited segment windows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class RunResult:
+    batch: int
+    iteration: int
+    command: str
+    returncode: int
+
+
+def run_once(script: Path, batch: int, iteration: int, seed: str) -> RunResult:
+    env = os.environ.copy()
+    env.setdefault("TME_SIMULATION_MODE", "1")
+    env.setdefault("TME_SEED", seed)
+
+    completed = subprocess.run(
+        ["bash", str(script)],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return RunResult(batch=batch, iteration=iteration, command=str(script), returncode=completed.returncode)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run deterministic timing mitigation verification batches.")
+    parser.add_argument("--batches", type=int, default=4)
+    parser.add_argument("--runs-per-batch", type=int, default=100)
+    parser.add_argument("--seed", default="0x4941544f2d5637")
+    parser.add_argument("--allowed-return-codes", default="0,42")
+    parser.add_argument(
+        "--scripts",
+        nargs="+",
+        default=[
+            "scripts/ensure-dotnet.sh",
+            "scripts/recover-dotnet-from-archive.sh",
+            "scripts/build-nfcreader-offline.sh",
+        ],
+        help="scripts to execute in order for each run",
+    )
+    args = parser.parse_args()
+
+    script_paths = [Path(script).resolve() for script in args.scripts]
+    missing = [str(path) for path in script_paths if not path.exists()]
+    if missing:
+        print("missing scripts:", ", ".join(missing), file=sys.stderr)
+        return 2
+
+    allowed_codes = {int(value) for value in args.allowed_return_codes.split(",") if value.strip()}
+
+    failures: list[RunResult] = []
+
+    for batch in range(1, args.batches + 1):
+        for iteration in range(1, args.runs_per_batch + 1):
+            for script in script_paths:
+                result = run_once(script, batch, iteration, args.seed)
+                if result.returncode not in allowed_codes:
+                    failures.append(result)
+
+    total_runs = args.batches * args.runs_per_batch * len(script_paths)
+    passed = total_runs - len(failures)
+
+    print(f"seed={args.seed} batches={args.batches} runs_per_batch={args.runs_per_batch}")
+    print(f"total={total_runs} passed={passed} failed={len(failures)}")
+
+    if failures:
+        for failure in failures[:20]:
+            print(
+                f"failure batch={failure.batch} iteration={failure.iteration} "
+                f"script={failure.command} rc={failure.returncode}",
+                file=sys.stderr,
+            )
+        if len(failures) > 20:
+            print(f"... {len(failures) - 20} additional failures omitted", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-hw-harness.sh
+++ b/scripts/run-hw-harness.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+export IATO_OPERATOR="${IATO_OPERATOR:-${USER:-unknown}}"
+export IATO_PRNG_SEED="${IATO_PRNG_SEED:-0x4941544f2d5637}"
+
+exec "${ROOT_DIR}/scripts/qemu-harness.sh" "$@"

--- a/scripts/start-spdm-responder.sh
+++ b/scripts/start-spdm-responder.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+IATO_SPDM_RESPONDER="${IATO_SPDM_RESPONDER:-${ROOT_DIR}/build/libspdm/bin/spdm_responder_emu}"
+SPDM_SOCK="${IATO_SPDM_SOCK:-/tmp/iato-spdm.sock}"
+SPDM_PID="${IATO_SPDM_PID:-/tmp/iato-spdm.pid}"
+SPDM_LOG="${IATO_SPDM_LOG:-/tmp/iato-spdm.log}"
+IATO_WAIT_LOOPS="${IATO_WAIT_LOOPS:-50}"
+
+log() { echo "[spdm] $*"; }
+err() { echo "[spdm][error] $*" >&2; }
+
+command -v nc >/dev/null 2>&1 || { err "missing command: nc"; exit 1; }
+[[ -x "${IATO_SPDM_RESPONDER}" ]] || { err "responder missing or not executable: ${IATO_SPDM_RESPONDER}"; exit 1; }
+
+if [[ -f "${SPDM_PID}" ]]; then
+  existing_pid="$(cat "${SPDM_PID}" 2>/dev/null || true)"
+  if [[ -n "${existing_pid}" ]] && kill -0 "${existing_pid}" >/dev/null 2>&1; then
+    log "already running (pid=${existing_pid})"
+    exit 0
+  fi
+fi
+
+rm -f "${SPDM_SOCK}" "${SPDM_PID}"
+"${IATO_SPDM_RESPONDER}" --trans socket --socket-path "${SPDM_SOCK}" >>"${SPDM_LOG}" 2>&1 &
+echo $! > "${SPDM_PID}"
+
+for _ in $(seq 1 "${IATO_WAIT_LOOPS}"); do
+  if nc -z -U "${SPDM_SOCK}" >/dev/null 2>&1; then
+    log "ready: socket=${SPDM_SOCK} pid=$(cat "${SPDM_PID}")"
+    exit 0
+  fi
+  sleep 0.1
+done
+
+err "responder did not become ready: ${SPDM_SOCK}"
+exit 1

--- a/scripts/start-swtpm.sh
+++ b/scripts/start-swtpm.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SWTPM_DIR="${IATO_SWTPM_DIR:-/tmp/iato-swtpm}"
+SWTPM_SOCK="${IATO_SWTPM_SOCK:-${SWTPM_DIR}/swtpm.sock}"
+SWTPM_PID="${IATO_SWTPM_PID:-${SWTPM_DIR}/swtpm.pid}"
+IATO_WAIT_LOOPS="${IATO_WAIT_LOOPS:-50}"
+
+log() { echo "[swtpm] $*"; }
+err() { echo "[swtpm][error] $*" >&2; }
+
+command -v swtpm >/dev/null 2>&1 || { err "missing command: swtpm"; exit 1; }
+command -v nc >/dev/null 2>&1 || { err "missing command: nc"; exit 1; }
+
+if [[ -f "${SWTPM_PID}" ]]; then
+  existing_pid="$(cat "${SWTPM_PID}" 2>/dev/null || true)"
+  if [[ -n "${existing_pid}" ]] && kill -0 "${existing_pid}" >/dev/null 2>&1; then
+    log "already running (pid=${existing_pid})"
+    exit 0
+  fi
+fi
+
+mkdir -p "${SWTPM_DIR}"
+rm -f "${SWTPM_SOCK}" "${SWTPM_PID}"
+
+swtpm socket \
+  --tpmstate dir="${SWTPM_DIR}" \
+  --ctrl type=unixio,path="${SWTPM_SOCK}" \
+  --tpm2 --daemon --pid "${SWTPM_PID}"
+
+for _ in $(seq 1 "${IATO_WAIT_LOOPS}"); do
+  if nc -z -U "${SWTPM_SOCK}" >/dev/null 2>&1; then
+    log "ready: socket=${SWTPM_SOCK} pid=$(cat "${SWTPM_PID}")"
+    exit 0
+  fi
+  sleep 0.1
+done
+
+err "swtpm did not become ready: ${SWTPM_SOCK}"
+exit 1

--- a/scripts/timing-engine.sh
+++ b/scripts/timing-engine.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Compatibility entrypoint for the timing mitigation engine referenced in docs.
+# shellcheck disable=SC1091
+source "$(dirname "$0")/timing_mitigation_engine.sh"

--- a/tests/hw-results.md
+++ b/tests/hw-results.md
@@ -1,0 +1,17 @@
+# QEMU Harness Hardware Results
+
+This file is generated/updated by `scripts/qemu-harness.sh` after a harness run.
+
+## Current status
+- No harness execution has been recorded in this working tree yet.
+- Run `./scripts/qemu-harness.sh` to populate this report with TPM/SPDM/SMMU/CNTHP results.
+
+## Expected metadata fields
+- Git SHA
+- Branch
+- Operator
+- PRNG seed
+- Hardware pass/fail summary
+
+## Runtime socket paths
+- TPM control socket: `/tmp/iato-swtpm/swtpm.sock`


### PR DESCRIPTION
### Motivation
- Make the harness-generated hardware report explicitly list the swtpm control socket so users and automation know the exact socket path used at runtime. 
- Address an inline review request to expose `/tmp/iato-swtpm/swtpm.sock` in the starter results template for clarity when no run has been recorded.

### Description
- Updated the results writer in `scripts/qemu-harness.sh` so the TPM line now includes the explicit socket path: `/tmp/iato-swtpm/swtpm.sock`.
- Added a `## Runtime socket paths` section to `tests/hw-results.md` that documents `TPM control socket: /tmp/iato-swtpm/swtpm.sock` in the starter template.

### Testing
- Ran `bash -n scripts/qemu-harness.sh` to validate shell syntax, which succeeded.
- Verified the changes are present with `rg -n "/tmp/iato-swtpm/swtpm.sock|TPM:" scripts/qemu-harness.sh tests/hw-results.md`, which found the updated entries.
- Inspected the starter template with `sed -n '1,80p' tests/hw-results.md` to confirm the new runtime socket section was added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ccd6442548328a271f1ccc990547c)