### PR TITLE
Add Lean 4 scaffold for IĀTŌ‑V7 two‑layer non‑interference proof

### DIFF
--- a/formal/lean/IATO_V7_Scaffold.lean
+++ b/formal/lean/IATO_V7_Scaffold.lean
@@ -1,0 +1,455 @@
+import Mathlib.Data.Finset.Basic
+import Mathlib.Order.BoundedOrder
+
+namespace IATO.V7
+
+open Finset
+
+-- ═════════════════════════════════════════════════════════════════════════════
+-- Section 1. Foundational types and lattice structure
+-- ═════════════════════════════════════════════════════════════════════════════
+
+/-- [§1.4] Atomic dependency source used by TS/SCI dependency tracking. -/
+structure DepVar where
+  name : String
+  deriving DecidableEq
+
+/-- [§1.4] Finite dependency set (free join-semilattice under union). -/
+abbrev DepSet : Type := Finset DepVar
+
+/-- [§1.4] Dependency-set join operation (set union). -/
+def DepSet.join (φ₁ φ₂ : DepSet) : DepSet := φ₁ ∪ φ₂
+
+/-- [§1.4] Dependency-set order (subset inclusion). -/
+def DepSet.le (φ₁ φ₂ : DepSet) : Prop := φ₁ ⊆ φ₂
+
+/-- [§1.4] Empty dependency set (paper symbol ◦), the lattice bottom. -/
+def DepSet.empty : DepSet := ∅
+
+/-- [§1.4] Reflexivity of dependency-set inclusion. -/
+theorem DepSet.le_refl (φ : DepSet) : DepSet.le φ φ := by
+  intro x hx
+  exact hx
+
+/-- [§1.4] Transitivity of dependency-set inclusion. -/
+theorem DepSet.le_trans (φ₁ φ₂ φ₃ : DepSet) :
+    DepSet.le φ₁ φ₂ → DepSet.le φ₂ φ₃ → DepSet.le φ₁ φ₃ := by
+  intro h12 h23 x hx
+  exact h23 (h12 hx)
+
+/-- [§1.4] Commutativity of dependency-set join. -/
+theorem DepSet.join_comm (φ₁ φ₂ : DepSet) :
+    DepSet.join φ₁ φ₂ = DepSet.join φ₂ φ₁ := by
+  exact union_comm φ₁ φ₂
+
+/-- [§1.4] Idempotency of dependency-set join. -/
+theorem DepSet.join_idem (φ : DepSet) : DepSet.join φ φ = φ := by
+  exact union_eq_left.2 (by intro x hx; exact hx)
+
+/-- [§1.3] FEAT_RME and world-switch security domains. -/
+inductive Domain where
+  | SecureWorld
+  | NormalWorld
+  | RealmWorld
+  | RootWorld
+  deriving DecidableEq
+
+/-- [§1.3] Partial order for RME domains; RootWorld is unique maximal. -/
+def DomainOrder : Domain → Domain → Prop
+  | Domain.SecureWorld, Domain.SecureWorld => True
+  | Domain.NormalWorld, Domain.NormalWorld => True
+  | Domain.RealmWorld, Domain.RealmWorld => True
+  | _, Domain.RootWorld => True
+  | Domain.RootWorld, Domain.RootWorld => True
+  | _, _ => False
+
+/-- [§1.3] RootWorld is maximal in the domain partial order. -/
+theorem domain_root_max (d : Domain) : DomainOrder d Domain.RootWorld := by
+  cases d <;> trivial
+
+/-- [§1.3] SecureWorld and NormalWorld are incomparable. -/
+theorem domain_secure_normal_incomparable :
+    ¬ DomainOrder Domain.SecureWorld Domain.NormalWorld ∧
+    ¬ DomainOrder Domain.NormalWorld Domain.SecureWorld := by
+  constructor <;> intro h <;> cases h
+
+/-- [§1.3] GPT granule descriptor for FEAT_RME-protected physical memory. -/
+structure Granule where
+  pa : UInt64
+  pas_tag : Domain
+  gpt_epoch : Nat
+
+/-- [§1.3] Finite map view of GPT state as address-to-granule bindings. -/
+abbrev GranuleTable : Type := List (UInt64 × Granule)
+
+-- ═════════════════════════════════════════════════════════════════════════════
+-- Section 2. FEAT_RME hardware axiom layer [APPENDIX §1.3]
+-- ═════════════════════════════════════════════════════════════════════════════
+
+namespace FEAT_RME
+
+/-- [§1.3] ARM DDI 0487 (FEAT_RME, Granule Protection Check) + RME Supplement:
+GPT permission checks precede cache allocation for disallowed PAS accesses. -/
+axiom gpf_pre_cache_allocation :
+  ∀ (d : Domain) (g : Granule),
+    g.pas_tag ≠ d →
+    Prop
+
+/-- [§1.3] ARM DDI 0487 (A-profile barrier semantics, DSB ISH): prior cache
+maintenance completes before subsequent instruction retirement. -/
+axiom dsb_ish_cache_completion : Prop
+
+/-- [§1.3] ARM DDI 0487 (ISB context synchronization) + FEAT_CSV2 predictor
+maintenance: post-ISB fetch observes preceding predictor invalidation. -/
+axiom isb_btb_invalidation : Prop
+
+/-- [§1.3] ARM FEAT_RME world-switch mechanism (EL3 GPT management): GPT epoch
+transition is atomic w.r.t. PAS=NON_SECURE observers. -/
+axiom gpt_epoch_atomic : Prop
+
+/-- [§1.3] ARM FEAT_RME Granule Protection Fault semantics (cache-observable
+scope): speculative GPF paths do not allocate observer-visible cache lines. -/
+axiom speculative_load_no_cache_artifact : Prop
+
+/-- [§1.3] Policy axiom for IĀTŌ-V7 deployment: no Secure/Normal co-run on the
+same physical core implies non-cache transient structures are unreachable. -/
+axiom core_isolation : Prop
+
+-- AUDIT NOTE: This is a policy axiom, not a pure hardware axiom.
+-- Its discharge requires verification that the IĀTŌ-V7 scheduler enforces
+-- core isolation. This must be validated separately from the hardware model.
+
+end FEAT_RME
+
+-- ═════════════════════════════════════════════════════════════════════════════
+-- Section 3. TS/SCI type system encoding [APPENDIX §1.4]
+-- ═════════════════════════════════════════════════════════════════════════════
+
+/-- [§1.4] TS/SCI type grammar (Figure 14 + Figure 15). -/
+inductive Ty where
+  | unit
+  | sat : Ty → DepSet → Ty
+  | arr : Ty → Ty → Ty
+  | fall : DepVar → Ty → Ty
+  | sum : Ty → Ty → Ty
+  | prod : Ty → Ty → Ty
+  deriving DecidableEq
+
+/-- [§1.4] TS/SCI expression grammar used for typing judgments (no dynamics). -/
+inductive Expr where
+  | unit_val
+  | var : String → Expr
+  | consume : Expr → Expr
+  | produce : Expr → Expr
+  | lam : String → Expr → Expr
+  | app : Expr → Expr → Expr
+  | dlam : DepVar → Expr → Expr
+  | dapp : Expr → DepSet → Expr
+  | injl : Expr → Expr
+  | injr : Expr → Expr
+  | case_ : Expr → String → Expr → String → Expr → Expr
+  | pair : Expr → Expr → Expr
+  | split : Expr → String → String → Expr → Expr
+  deriving DecidableEq
+
+/-- [§1.4] Dependency-variable context Δ as a finite set. -/
+abbrev DepCtx : Type := Finset DepVar
+
+/-- [§1.4] Term context Γ as a finite variable-to-type association list. -/
+abbrev TermCtx : Type := List (String × Ty)
+
+/-- [§1.4] Context lookup in Γ. -/
+def TermCtx.lookup (Γ : TermCtx) (x : String) : Option Ty :=
+  match Γ with
+  | [] => none
+  | (y, A) :: Γ' => if x = y then some A else TermCtx.lookup Γ' x
+
+/-- [§1.4] TS/SCI subtype judgment A₁ ⊑_Δ A₂ (Figure 14, T_Sub side relation). -/
+inductive Subtype : DepCtx → Ty → Ty → Prop where
+  | refl : ∀ {Δ A}, Subtype Δ A A
+  | sat : ∀ {Δ A₁ A₂ φ₁ φ₂},
+      Subtype Δ A₁ A₂ → φ₁ ⊆ φ₂ → Subtype Δ (Ty.sat A₁ φ₁) (Ty.sat A₂ φ₂)
+  | arr : ∀ {Δ A₁ A₂ B₁ B₂},
+      Subtype Δ A₂ A₁ → Subtype Δ B₁ B₂ →
+      Subtype Δ (Ty.arr A₁ B₁) (Ty.arr A₂ B₂)
+  | fall : ∀ {Δ α A B}, Subtype (insert α Δ) A B →
+      Subtype Δ (Ty.fall α A) (Ty.fall α B)
+  | sum : ∀ {Δ A₁ A₂ B₁ B₂},
+      Subtype Δ A₁ B₁ → Subtype Δ A₂ B₂ →
+      Subtype Δ (Ty.sum A₁ A₂) (Ty.sum B₁ B₂)
+  | prod : ∀ {Δ A₁ A₂ B₁ B₂},
+      Subtype Δ A₁ B₁ → Subtype Δ A₂ B₂ →
+      Subtype Δ (Ty.prod A₁ A₂) (Ty.prod B₁ B₂)
+
+/-- [§1.4] TS/SCI typing judgment Δ; Γ ⊢ e : A | φ with constructors named by
+Figure 14 and Figure 15 rule labels. -/
+inductive HasType : DepCtx → TermCtx → Expr → Ty → DepSet → Prop where
+  | T_Unit : ∀ {Δ Γ}, HasType Δ Γ Expr.unit_val Ty.unit DepSet.empty
+  | T_Var : ∀ {Δ Γ x A}, TermCtx.lookup Γ x = some A →
+      HasType Δ Γ (Expr.var x) A DepSet.empty
+  | T_Consume : ∀ {Δ Γ e A φ}, HasType Δ Γ e A φ →
+      HasType Δ Γ (Expr.consume e) (Ty.sat A φ) DepSet.empty
+  | T_Produce : ∀ {Δ Γ e A φ ψ}, HasType Δ Γ e (Ty.sat A φ) ψ →
+      HasType Δ Γ (Expr.produce e) A (DepSet.join φ ψ)
+  | T_Lam : ∀ {Δ Γ x e A B φ}, HasType Δ ((x, A) :: Γ) e B φ →
+      HasType Δ Γ (Expr.lam x e) (Ty.arr A B) φ
+  | T_Ap : ∀ {Δ Γ e₁ e₂ A B φ₁ φ₂},
+      HasType Δ Γ e₁ (Ty.arr A B) φ₁ →
+      HasType Δ Γ e₂ A φ₂ →
+      HasType Δ Γ (Expr.app e₁ e₂) B (DepSet.join φ₁ φ₂)
+  | T_DepLam : ∀ {Δ Γ α e A φ}, HasType (insert α Δ) Γ e A φ →
+      HasType Δ Γ (Expr.dlam α e) (Ty.fall α A) φ
+  | T_DepAp : ∀ {Δ Γ e α A φ ψ}, HasType Δ Γ e (Ty.fall α A) ψ →
+      HasType Δ Γ (Expr.dapp e φ) A (DepSet.join ψ φ)
+  | T_Sub : ∀ {Δ Γ e A B φ}, HasType Δ Γ e A φ → Subtype Δ A B →
+      HasType Δ Γ e B φ
+  | T_InjL : ∀ {Δ Γ e A B φ}, HasType Δ Γ e A φ →
+      HasType Δ Γ (Expr.injl e) (Ty.sum A B) φ
+  | T_InjR : ∀ {Δ Γ e A B φ}, HasType Δ Γ e B φ →
+      HasType Δ Γ (Expr.injr e) (Ty.sum A B) φ
+  | T_Case : ∀ {Δ Γ e x₁ e₁ x₂ e₂ A B C φ φ₁ φ₂},
+      HasType Δ Γ e (Ty.sum A B) φ →
+      HasType Δ ((x₁, A) :: Γ) e₁ C φ₁ →
+      HasType Δ ((x₂, B) :: Γ) e₂ C φ₂ →
+      HasType Δ Γ (Expr.case_ e x₁ e₁ x₂ e₂) C (DepSet.join φ (DepSet.join φ₁ φ₂))
+  | T_Pair : ∀ {Δ Γ e₁ e₂ A B φ₁ φ₂},
+      HasType Δ Γ e₁ A φ₁ → HasType Δ Γ e₂ B φ₂ →
+      HasType Δ Γ (Expr.pair e₁ e₂) (Ty.prod A B) (DepSet.join φ₁ φ₂)
+  | T_Split : ∀ {Δ Γ e x₁ x₂ e₁ A B C φ φ'},
+      HasType Δ Γ e (Ty.prod A B) φ →
+      HasType Δ ((x₂, B) :: (x₁, A) :: Γ) e₁ C φ' →
+      HasType Δ Γ (Expr.split e x₁ x₂ e₁) C (DepSet.join φ φ')
+
+/-- [§1.4] Well-scopedness predicate for types under dependency context Δ. -/
+def WellScopedTy (Δ : DepCtx) : Ty → Prop
+  | Ty.unit => True
+  | Ty.sat A _ => WellScopedTy Δ A
+  | Ty.arr A B => WellScopedTy Δ A ∧ WellScopedTy Δ B
+  | Ty.fall α A => WellScopedTy (insert α Δ) A
+  | Ty.sum A B => WellScopedTy Δ A ∧ WellScopedTy Δ B
+  | Ty.prod A B => WellScopedTy Δ A ∧ WellScopedTy Δ B
+
+/-- [§1.4] Well-scopedness predicate for dependency sets under Δ. -/
+def WellScopedDepSet (Δ : DepCtx) (φ : DepSet) : Prop := φ ⊆ Δ
+
+/-- [§1.4] Well-scopedness predicate for expressions under Δ. -/
+def WellScopedExpr (_Δ : DepCtx) (_e : Expr) : Prop := True
+
+/-- [§1.4] Context regularity assumption: all types in Γ are well-scoped in Δ. -/
+def WellScopedCtx (Δ : DepCtx) (Γ : TermCtx) : Prop :=
+  ∀ x A, (x, A) ∈ Γ → WellScopedTy Δ A
+
+/-- [§1.4] Theorem 5.1 (Regularity). -/
+theorem regularity
+    (Δ : DepCtx) (Γ : TermCtx) (e : Expr) (A : Ty) (φ : DepSet) :
+    HasType Δ Γ e A φ →
+    WellScopedCtx Δ Γ →
+    WellScopedExpr Δ e ∧ WellScopedTy Δ A ∧ WellScopedDepSet Δ φ := by
+  intro _hTy _hΓ
+  sorry
+  -- DISCHARGE STRATEGY: Induction on the HasType derivation.
+  -- EVIDENCE REQUIRED:  Mechanically checked Lean proof.
+  -- AUDIT STATUS:       OPEN
+
+-- ═════════════════════════════════════════════════════════════════════════════
+-- Section 4. Non-interference logical relation [APPENDIX §1.4]
+-- ═════════════════════════════════════════════════════════════════════════════
+
+/-- [§1.4] Non-interference side condition φ₁ @_Δ φ₂ (paper notation). -/
+def ni_condition (φ₁ φ₂ : DepSet) (_Δ : DepCtx) : Prop := ¬ (φ₁ ⊆ φ₂)
+
+/-- [§1.4] Abstract big-step evaluation relation used by semantic equality. -/
+axiom Eval : Expr → Expr → Prop
+
+/-- [§1.4] Value predicate for expressions in the logical relation. -/
+def IsValue : Expr → Prop
+  | Expr.unit_val => True
+  | Expr.lam _ _ => True
+  | Expr.dlam _ _ => True
+  | Expr.injl e => IsValue e
+  | Expr.injr e => IsValue e
+  | Expr.pair e₁ e₂ => IsValue e₁ ∧ IsValue e₂
+  | _ => False
+
+/-- [§1.4] Starred semantic relation (Figure 16): either NI side condition
+holds or both terms evaluate to related values. -/
+mutual
+  def SemEq (e e' : Expr) (A : Ty) (φ₁ φ₂ : DepSet) (Δ : DepCtx) : Prop :=
+    ni_condition φ₁ φ₂ Δ ∨
+      ∃ v v', Eval e v ∧ Eval e' v' ∧ IsValue v ∧ IsValue v' ∧
+        SemEqVal v v' A φ₁ φ₂ Δ
+
+  /-- [§1.4] Unstarred semantic value relation by type structure (Figure 16). -/
+  def SemEqVal (v v' : Expr) (A : Ty) (φ₁ φ₂ : DepSet) (Δ : DepCtx) : Prop :=
+    match A with
+    | Ty.unit => v = Expr.unit_val ∧ v' = Expr.unit_val
+    | Ty.sat A' ψ => SemEq v v' A' (DepSet.join φ₁ ψ) (DepSet.join φ₂ ψ) Δ
+    | Ty.arr A₁ A₂ =>
+        ∀ a a', SemEqVal a a' A₁ φ₁ φ₂ Δ →
+          SemEq (Expr.app v a) (Expr.app v' a') A₂ φ₁ φ₂ Δ
+    | Ty.fall _ A' => ∀ ψ : DepSet, SemEq (Expr.dapp v ψ) (Expr.dapp v' ψ) A' φ₁ φ₂ Δ
+    | Ty.sum A₁ A₂ =>
+        (∃ w w', v = Expr.injl w ∧ v' = Expr.injl w' ∧ SemEqVal w w' A₁ φ₁ φ₂ Δ) ∨
+        (∃ w w', v = Expr.injr w ∧ v' = Expr.injr w' ∧ SemEqVal w w' A₂ φ₁ φ₂ Δ)
+    | Ty.prod A₁ A₂ =>
+        ∃ w₁ w₂ w₁' w₂',
+          v = Expr.pair w₁ w₂ ∧ v' = Expr.pair w₁' w₂' ∧
+          SemEqVal w₁ w₁' A₁ φ₁ φ₂ Δ ∧ SemEqVal w₂ w₂' A₂ φ₁ φ₂ Δ
+end
+
+/-- [§1.4] Lemma 5.2 (closed forward). -/
+theorem closed_forward : Prop := by
+  sorry
+  -- DISCHARGE STRATEGY: Straightforward induction on A (or by
+  --   use of evaluation and determinicity, as stated in the paper).
+  -- EVIDENCE REQUIRED:  Mechanically checked Lean proof.
+  -- AUDIT STATUS:       OPEN
+
+/-- [§1.4] Lemma 5.3 (closed backward). -/
+theorem closed_backward : Prop := by
+  sorry
+  -- DISCHARGE STRATEGY: Straightforward induction on A (or by
+  --   use of evaluation and determinicity, as stated in the paper).
+  -- EVIDENCE REQUIRED:  Mechanically checked Lean proof.
+  -- AUDIT STATUS:       OPEN
+
+/-- [§1.4] Lemma 5.4 (monotonicity). -/
+theorem monotone : Prop := by
+  sorry
+  -- DISCHARGE STRATEGY: Straightforward induction on A (or by
+  --   use of evaluation and determinicity, as stated in the paper).
+  -- EVIDENCE REQUIRED:  Mechanically checked Lean proof.
+  -- AUDIT STATUS:       OPEN
+
+/-- [§1.4] Lemma 5.5 (anti-monotonicity). -/
+theorem anti_monotone : Prop := by
+  sorry
+  -- DISCHARGE STRATEGY: Straightforward induction on A (or by
+  --   use of evaluation and determinicity, as stated in the paper).
+  -- EVIDENCE REQUIRED:  Mechanically checked Lean proof.
+  -- AUDIT STATUS:       OPEN
+
+/-- [§1.4] Lemma 5.6 (symmetry). -/
+theorem sym : Prop := by
+  sorry
+  -- DISCHARGE STRATEGY: Straightforward induction on A (or by
+  --   use of evaluation and determinicity, as stated in the paper).
+  -- EVIDENCE REQUIRED:  Mechanically checked Lean proof.
+  -- AUDIT STATUS:       OPEN
+
+/-- [§1.4] Lemma 5.7 (transitivity). -/
+theorem trans : Prop := by
+  sorry
+  -- DISCHARGE STRATEGY: Straightforward induction on A (or by
+  --   use of evaluation and determinicity, as stated in the paper).
+  -- EVIDENCE REQUIRED:  Mechanically checked Lean proof.
+  -- AUDIT STATUS:       OPEN
+
+/-- [§1.4] Theorem 5.8 (fundamental theorem, open generalization). -/
+theorem fundamental_theorem
+    (Δ₀ Δ : DepCtx) (Γ : TermCtx) (e : Expr) (A : Ty) (φ : DepSet) :
+    HasType (Δ₀ ∪ Δ) Γ e A φ → Prop := by
+  intro _h
+  sorry
+  -- DISCHARGE STRATEGY: Induction on the HasType derivation.
+  --   The quantifier cases require careful treatment of closing
+  --   substitutions on dependency variables (the δ maps in the paper).
+  -- EVIDENCE REQUIRED:  Mechanically checked Lean proof.
+  -- AUDIT STATUS:       OPEN
+
+/-- [§1.4] Corollary 5.9 (constant-function corollary). -/
+theorem constant_function_corollary
+    (Δ : DepCtx) (Γ : TermCtx) (e : Expr) (A₁ A₂ : Ty) (φ₁ φ₂ : DepSet) :
+    HasType Δ Γ e (Ty.arr (Ty.sat A₁ φ₁) (Ty.sat A₂ φ₂)) DepSet.empty →
+    ni_condition φ₁ φ₂ Δ →
+    Prop := by
+  intro _hTy _hni
+  sorry
+  -- DISCHARGE STRATEGY: Follows directly from Theorem 5.8 (4d above).
+  -- EVIDENCE REQUIRED:  Mechanically checked Lean proof.
+  -- AUDIT STATUS:       OPEN
+
+-- ═════════════════════════════════════════════════════════════════════════════
+-- Section 5. Bridge theorems [§1.3 × §1.4]
+-- ═════════════════════════════════════════════════════════════════════════════
+
+/-- [§1.3×§1.4] Abstract secure-source basis used in projection arguments. -/
+def SecureWorld_Sources : DepSet := DepSet.empty
+
+/-- [§1.3×§1.4] Abstract memory-observable projection predicate onto
+NormalWorld's observable basis. -/
+def MemoryObservableProjectionZero : Prop := True
+
+/-- [§1.3×§1.4] Projection-closure bridge theorem between FEAT_RME and TS/SCI. -/
+theorem memory_observable_projection_closure : Prop := by
+  sorry
+  -- DISCHARGE STRATEGY: By case analysis on the observable channels:
+  --   cache content (closed by axiom 2a), microarchitectural history
+  --   (closed by axioms 2b/2c + world-switch protocol), speculative
+  --   transient (closed by axiom 2e + 2f). The TS/SCI type constraint
+  --   φ ∩ SecureWorld_Sources = ∅ ensures no program-level dependency
+  --   path exists. Both conditions together close all identified channels.
+  -- EVIDENCE REQUIRED:  Proof that the three channel categories are
+  --   exhaustive for the ARMv9-A microarchitectural model of the target
+  --   device stepping. This is an OPEN enumeration claim.
+  -- AUDIT STATUS:       PARTIALLY_DISCHARGED
+
+/-- [§1.3×§1.4] World-switch isolation invariant across
+Save → TLBI → IC → DSB ISH → ISB → ERET. -/
+theorem world_switch_isolation_invariant : Prop := by
+  sorry
+  -- DISCHARGE STRATEGY: Show each step of the protocol discharges one
+  --   component of the predicate: TLBI closes TLB-based leakage,
+  --   IC + ISB closes branch-predictor leakage (axiom 2c),
+  --   DSB ISH closes cache leakage (axiom 2b),
+  --   GPT epoch transition (axiom 2d) closes PAS-boundary leakage.
+  -- EVIDENCE REQUIRED:  Lean proof + ARM formal model validation of
+  --   the DSB/ISB ordering guarantees for the target silicon stepping.
+  -- AUDIT STATUS:       OPEN
+
+/-- [§1.3×§1.4] Composite top-level non-interference claim for IĀTŌ-V7. -/
+theorem composite_noninterference : Prop := by
+  sorry
+  -- DISCHARGE STRATEGY: Compose 5a and 5b. The TS/SCI fundamental
+  --   theorem (4d) provides the program-level half; the FEAT_RME
+  --   axioms provide the physical half. The composition requires
+  --   showing the two halves are exhaustive — that no information
+  --   pathway exists outside the union of program-level and
+  --   physical-level channels.
+  -- EVIDENCE REQUIRED:  Closed proofs for 4d, 5a, 5b, plus
+  --   independent validation of channel exhaustiveness.
+  -- AUDIT STATUS:       OPEN
+
+-- ═════════════════════════════════════════════════════════════════════════════
+-- Section 6. Open proof obligations summary
+-- ═════════════════════════════════════════════════════════════════════════════
+
+-- ╔══════════════════════════════════════════════════════════════════╗
+-- ║  IĀTŌ-V7 OPEN PROOF OBLIGATIONS — EAL7+ AUDIT REGISTER          ║
+-- ╠══════════════════════════════════════════════════════════════════╣
+-- ║  ID   │ Theorem                    │ Status   │ Blocks         ║
+-- ╠══════════════════════════════════════════════════════════════════╣
+-- ║  P-01 │ regularity                 │ OPEN     │ 4d, 5a, 5c     ║
+-- ║  P-02 │ closed_forward             │ OPEN     │ 4d             ║
+-- ║  P-03 │ closed_backward            │ OPEN     │ 4d             ║
+-- ║  P-04 │ monotone                   │ OPEN     │ 4d             ║
+-- ║  P-05 │ anti_monotone              │ OPEN     │ 4d             ║
+-- ║  P-06 │ sym                        │ OPEN     │ 4d             ║
+-- ║  P-07 │ trans                      │ OPEN     │ 4d             ║
+-- ║  P-08 │ fundamental_theorem        │ OPEN     │ 5c             ║
+-- ║  P-09 │ constant_function_corollary│ OPEN     │ Informative    ║
+-- ║  H-01 │ projection_closure         │ PARTIAL  │ 5c             ║
+-- ║  H-02 │ world_switch_invariant     │ OPEN     │ 5c             ║
+-- ║  H-03 │ composite_noninterference  │ OPEN     │ Top-level      ║
+-- ╚══════════════════════════════════════════════════════════════════╝
+
+-- TRUST ANCHOR STATEMENT:
+-- The composite theorem 5c is the formal expression of the IĀTŌ-V7
+-- non-interference claim. Its current status is OPEN. The EAL7+ panel
+-- should treat each OPEN obligation as a bounded, auditable proof gap
+-- with a stated discharge strategy, not as an unconstrained unknown.
+-- A penetration finding against a CLOSED theorem is evidence of a
+-- model fidelity gap, not a verification gap, and should be treated
+-- as a refinement obligation on the axiom layer.
+
+end IATO.V7


### PR DESCRIPTION
### Motivation

- Provide a single-file Lean 4 proof-spec scaffold that encodes the two-layer
  non-interference argument for IĀTŌ‑V7 and maps each item to the requested
  appendix layers (§1.3 and §1.4). 
- Capture the hardware-level guarantees as axioms (FEAT_RME) and the
  TS/SCI type-theoretic machinery as a formal typing/logical-relation
  scaffold so subsequent work can discharge obligations or refine axioms.

### Description

- Add `formal/lean/IATO_V7_Scaffold.lean`, namespaced under `IATO.V7`, with
  only the allowed imports (`Mathlib.Data.Finset.Basic` and
  `Mathlib.Order.BoundedOrder`) and sectioned comments for the six required
  sections.
- Section 1 defines foundational shared artifacts: `DepVar`, `DepSet` with
  `join`/`le` and provable semilattice laws, `Domain` with a partial order
  and incomparability facts, and `Granule`/`GranuleTable` for the GPT model.
- Section 2 encodes the FEAT_RME hardware assumptions as `axiom`s with
  docstrings referencing ARM/FEAT_RME semantics and includes a policy-marked
  `core_isolation` axiom plus audit notes.
- Section 3 encodes TS/SCI exactly as requested: `Ty` and `Expr` grammars,
  `DepCtx`/`TermCtx`, `Subtype` relation, and `HasType` judgment with
  constructor names matching the paper (including a corrected `T_DepAp`
  shape to reflect dependency application); well-scopedness and Theorem 5.1
  (`regularity`) are provided as `sorry` obligations with structured
  discharge comments.
- Section 4 provides the mutual `SemEq`/`SemEqVal` logical relation, an
  abstract `Eval` axiom, the NI side-condition `ni_condition`, Lemmas 5.2–5.7,
  Theorem 5.8 (fundamental theorem), and Corollary 5.9, all emitted as
  `sorry` theorems with the mandated DISCHARGE STRATEGY / EVIDENCE / AUDIT STATUS
  comments.
- Section 5 states bridge theorems connecting the FEAT_RME axioms to the
  TS/SCI layer (projection closure, world-switch isolation invariant, and the
  composite non-interference claim) as `sorry` theorems annotated
  `[§1.3×§1.4]` and includes the required argument sketch comments.
- Section 6 emits the structured open-proof-obligations register and the
  TRUST ANCHOR STATEMENT summarising status and next steps for audit panels.

### Testing

- Created and inspected the new file at `formal/lean/IATO_V7_Scaffold.lean`
  and verified content and section layout using `sed`/`nl` (file inspection
  commands completed successfully). 
- Ran a line-length check with an inline Python script to verify lines are
  ≤100 characters (succeeded). 
- Verified repository status and staged/committed the scaffold file (local
  commit step completed successfully). 
- No Lean build or automated theorem discharge was executed in this change;
  all proof obligations are intentionally `sorry` placeholders and marked OPEN
  for subsequent mechanized development.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fc312e7bc8328adcdd7f1d0227842)