### PR TITLE
Align Armv9 CCA formal model with SSBS speculation control and adversarial hypervisor assumptions

### DIFF
--- a/formal/armv9_cca_confidential_compute_control_model.md
+++ b/formal/armv9_cca_confidential_compute_control_model.md
@@ -341,3 +341,22 @@ This repository now includes:
 - **14 Coq non-interference proof files** under `formal/coq/armv9_cca/`
 
 These files provide mechanically-checkable scaffolding for the invariants and proof obligations above.
+
+---
+
+
+## 10. Manual Alignment Audit Checklist (ARM DDI 0487 cross-check)
+
+Use this checklist to verify generated models are aligned with Armv9-A CCA assumptions and not merely generic barrier semantics:
+
+| Audit Area | Required String | Expected Modeling Behavior |
+| --- | --- | --- |
+| Security State | `SCR_EL3.NSE`, `SCR_EL3.NS` | World-selection logic must switch execution world from these two bits (`Realm`, `NonRealm`, `Secure`). |
+| Speculation Control | `PSTATE.SSBS` | Predicate where `PSTATE.SSBS == 1` prevents speculative load bypass of unresolved prior stores to same address (store-to-load forwarding gate). |
+| Memory Tagging | `GPI` and `GPT` | Every `Load`/`Store` transition must check GPT status (indexed by granule/GPI metadata) before memory access is considered granted. |
+
+Threat-model alignment requirement:
+
+* The Hypervisor must be modeled as a **Non-Realm adversary** (`hypervisorTrusted = FALSE`).
+* Any model that assumes a "trusted hypervisor" is out-of-scope for Arm CCA Realm threat assumptions.
+

--- a/formal/tla/armv9_cca/realm_noninterference_safety.tla
+++ b/formal/tla/armv9_cca/realm_noninterference_safety.tla
@@ -1,26 +1,73 @@
 ---------------------------- MODULE realm_noninterference_safety ----------------------------
 EXTENDS Naturals, FiniteSets, TLC
 
-CONSTANT Secrets, Observables
-VARIABLES world, realmSecret, nonRealmObs, leak
+CONSTANT Secrets, Observables, AddrSet
 
-RealmNonInterference == (world = "NonRealm") => (leak = FALSE)
+\* Security State: SCR_EL3.NSE, SCR_EL3.NS select world routing logic.
+\* Model alignment for Arm CCA: the Hypervisor is Non-Realm and adversarial.
+VARIABLES SCR_EL3_NSE, SCR_EL3_NS, executionWorld, hypervisorTrusted,
+          realmSecret, nonRealmObs, leak,
+          GPI, gptStatus, memOp, memAddr, memAccessGranted
+
+WorldFromSCR(nse, ns) ==
+  IF nse = 1 /\ ns = 1 THEN "NonRealm"
+  ELSE IF nse = 0 /\ ns = 0 THEN "Realm"
+  ELSE "Secure"
+
+\* Memory Tagging: GPI (Granule Protection Index) consults GPT before Load/Store.
+\* Load or Store is granted only if GPT status authorizes the world for that granule.
+GPTAllows(world, status) ==
+  CASE world = "Realm" -> status = "Realm"
+    [] world = "NonRealm" -> status = "NonRealm"
+    [] OTHER -> status = "Secure"
+
+GPTCheckedBeforeMemOp ==
+  (memOp \in {"Load", "Store"}) =>
+    (memAccessGranted = GPTAllows(executionWorld, gptStatus[memAddr]))
+
+RealmNonInterference == (executionWorld = "NonRealm") => (leak = FALSE)
+
+ThreatModelAligned == (hypervisorTrusted = FALSE) /\ (executionWorld = WorldFromSCR(SCR_EL3_NSE, SCR_EL3_NS))
 
 Init ==
-  /\ world \in {"Realm", "NonRealm", "Secure"}
+  /\ SCR_EL3_NSE \in {0, 1}
+  /\ SCR_EL3_NS \in {0, 1}
+  /\ executionWorld \in {"Realm", "NonRealm", "Secure"}
+  /\ hypervisorTrusted = FALSE
   /\ realmSecret \in Secrets
   /\ nonRealmObs \in Observables
   /\ leak \in BOOLEAN
+  /\ GPI \in AddrSet -> Nat
+  /\ gptStatus \in AddrSet -> {"Realm", "NonRealm", "Secure"}
+  /\ memOp \in {"None", "Load", "Store"}
+  /\ memAddr \in AddrSet
+  /\ memAccessGranted \in BOOLEAN
+  /\ ThreatModelAligned
+  /\ GPTCheckedBeforeMemOp
   /\ RealmNonInterference
 
 Next ==
-  /\ world' \in {"Realm", "NonRealm", "Secure"}
+  /\ SCR_EL3_NSE' \in {0, 1}
+  /\ SCR_EL3_NS' \in {0, 1}
+  /\ executionWorld' = WorldFromSCR(SCR_EL3_NSE', SCR_EL3_NS')
+  /\ hypervisorTrusted' = FALSE
   /\ realmSecret' \in Secrets
   /\ nonRealmObs' \in Observables
   /\ leak' \in BOOLEAN
-  /\ ((world' = "NonRealm") => (leak' = FALSE))
+  /\ GPI' \in AddrSet -> Nat
+  /\ gptStatus' \in AddrSet -> {"Realm", "NonRealm", "Secure"}
+  /\ memOp' \in {"None", "Load", "Store"}
+  /\ memAddr' \in AddrSet
+  /\ memAccessGranted' \in BOOLEAN
+  /\ ((memOp' \in {"Load", "Store"}) =>
+        (memAccessGranted' = GPTAllows(executionWorld', gptStatus'[memAddr'])))
+  /\ ((executionWorld' = "NonRealm") => (leak' = FALSE))
 
-Spec == Init /\ [][Next]_<<world, realmSecret, nonRealmObs, leak>>
+Spec == Init /\ [][Next]_<<SCR_EL3_NSE, SCR_EL3_NS, executionWorld, hypervisorTrusted,
+                           realmSecret, nonRealmObs, leak,
+                           GPI, gptStatus, memOp, memAddr, memAccessGranted>>
 
 THEOREM RealmNonInterferenceInvariant == Spec => []RealmNonInterference
+THEOREM ThreatModelAlignmentInvariant == Spec => []ThreatModelAligned
+THEOREM GPTCheckedBeforeMemOpInvariant == Spec => []GPTCheckedBeforeMemOp
 ===============================================================================================


### PR DESCRIPTION
### Motivation

- Ensure the formal CCA models treat SSBS as a speculation-control that gates store-to-load forwarding rather than a generic barrier. 
- Model world-selection and security state mapping from the `SCR_EL3.NSE`/`SCR_EL3.NS` bits so world switches are architecturally explicit. 
- Encode memory-tagging (`GPI`/`GPT`) checks and assume the Hypervisor is adversarial (Non-Realm) to match the Arm CCA threat model.

### Description

- Updated `formal/tla/armv9_cca/ssbs_store_load_ordering_safety.tla` to use `PSTATE_SSBS` and model the invariant that `PSTATE_SSBS = 1` prevents a younger load from bypassing an older unresolved store by setting `speculativeLoadBypassesStore = FALSE`.
- Extended `formal/tla/armv9_cca/realm_noninterference_safety.tla` to derive `executionWorld` from `SCR_EL3_NSE`/`SCR_EL3_NS`, add `GPI`/`gptStatus` state, require `GPT` checks before `Load`/`Store`, and fix `hypervisorTrusted = FALSE` with a `ThreatModelAligned` predicate and corresponding theorems.
- Added a `10. Manual Alignment Audit Checklist` to `formal/armv9_cca_confidential_compute_control_model.md` that lists required strings and expected behaviors for `SCR_EL3.NSE`, `SCR_EL3.NS`, `PSTATE.SSBS`, and `GPI`/`GPT`, and documents the hypervisor adversary assumption.

### Testing

- Ran `rg -n "SCR_EL3\.NSE|SCR_EL3\.NS|PSTATE\.SSBS|GPI|GPT|hypervisorTrusted|Load|Store"` across the updated model files to verify the required predicates and audit strings are present, and the search returned matches as expected. 
- Verified the updated TLA+ modules contain the expected invariant and theorem declarations (`SSBSOrderingInvariant`, `RealmNonInterferenceInvariant`, `ThreatModelAlignmentInvariant`, `GPTCheckedBeforeMemOpInvariant`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0164bfa4c8328992f901353314c97)