### PR TITLE
Add Lean diagnostics compose stack, CI setup script, and DepSet refactor in IATO.V7

### DIFF
--- a/docker/lean-diagnose/README.md
+++ b/docker/lean-diagnose/README.md
@@ -1,0 +1,28 @@
+# Lean Diagnose Compose Stack
+
+This compose stack runs Lean diagnostics in a background container and exposes the
+latest report through a reverse proxy web server.
+
+## Services
+
+- `lean-diagnose`: executes `formal/lean/scripts/virtual_lean_diagnose.sh` every 5 minutes and writes logs to a shared volume.
+- `lean-diagnose-web`: serves the shared report volume over HTTP on internal port `3000`.
+- `lean-diagnose-proxy`: nginx reverse proxy exposing the web service on `http://localhost:8088`.
+
+## Run (detached)
+
+```bash
+./scripts/run-lean-diagnose-compose.sh
+```
+
+Then open:
+
+- `http://127.0.0.1:8088/`
+- `http://127.0.0.1:8088/latest.log`
+- `http://127.0.0.1:8088/healthz`
+
+## Stop
+
+```bash
+docker compose -f docker/lean-diagnose/docker-compose.yml down
+```

--- a/docker/lean-diagnose/docker-compose.yml
+++ b/docker/lean-diagnose/docker-compose.yml
@@ -1,0 +1,40 @@
+services:
+  lean-diagnose:
+    build:
+      context: ../..
+      dockerfile: docker/lean-diagnose/Dockerfile
+    container_name: lean-diagnose-job
+    working_dir: /workspace
+    command: >-
+      /bin/bash -lc "
+      mkdir -p /reports &&
+      /workspace/formal/lean/scripts/virtual_lean_diagnose.sh 2>&1 | tee /reports/latest.log &&
+      while true; do
+        date -u '+%Y-%m-%dT%H:%M:%SZ' > /reports/last_run_utc.txt;
+        /workspace/formal/lean/scripts/virtual_lean_diagnose.sh > /reports/latest.log 2>&1 || true;
+        sleep 300;
+      done"
+    volumes:
+      - lean_diagnose_reports:/reports
+
+  lean-diagnose-web:
+    image: python:3.12-alpine
+    container_name: lean-diagnose-web
+    command: sh -c "cd /reports && python -m http.server 3000"
+    volumes:
+      - lean_diagnose_reports:/reports:ro
+    depends_on:
+      - lean-diagnose
+
+  lean-diagnose-proxy:
+    image: nginx:1.27-alpine
+    container_name: lean-diagnose-proxy
+    depends_on:
+      - lean-diagnose-web
+    ports:
+      - "8088:80"
+    volumes:
+      - ./reverse-proxy/default.conf:/etc/nginx/conf.d/default.conf:ro
+
+volumes:
+  lean_diagnose_reports:

--- a/docker/lean-diagnose/reverse-proxy/default.conf
+++ b/docker/lean-diagnose/reverse-proxy/default.conf
@@ -1,0 +1,27 @@
+server {
+  listen 80 default_server;
+  server_name _;
+
+  access_log /var/log/nginx/access.log;
+  error_log /var/log/nginx/error.log warn;
+
+  location = /healthz {
+    access_log off;
+    default_type text/plain;
+    return 200 'ok';
+  }
+
+  location / {
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Connection "";
+    proxy_buffering off;
+    proxy_read_timeout 60s;
+    proxy_connect_timeout 5s;
+    proxy_pass http://lean-diagnose-web:3000;
+  }
+}

--- a/formal/lean/IATO/V7.lean
+++ b/formal/lean/IATO/V7.lean
@@ -1,1 +1,47 @@
-import IATO_V7_Scaffold
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Finset.Lattice.Basic
+import Mathlib.Order.BoundedOrder
+
+namespace IATO.V7
+
+open Finset
+
+structure DepVar where
+  name : String
+  deriving DecidableEq
+
+abbrev DepSet : Type := Finset DepVar
+
+namespace DepSet
+
+def join (φ₁ φ₂ : DepSet) : DepSet := φ₁ ∪ φ₂
+
+def le (φ₁ φ₂ : DepSet) : Prop := φ₁ ⊆ φ₂
+
+def empty : DepSet := ∅
+
+lemma le_refl (φ : DepSet) : le φ φ := by
+  intro x hx
+  exact hx
+
+lemma le_trans {φ₁ φ₂ φ₃ : DepSet} : le φ₁ φ₂ → le φ₂ φ₃ → le φ₁ φ₃ := by
+  intro h₁₂ h₂₃ x hx
+  exact h₂₃ (h₁₂ hx)
+
+lemma join_comm (φ₁ φ₂ : DepSet) : join φ₁ φ₂ = join φ₂ φ₁ := by
+  exact Finset.union_comm φ₁ φ₂
+
+lemma join_idem (φ : DepSet) : join φ φ = φ := by
+  exact Finset.union_idem
+
+instance : PartialOrder DepSet := inferInstance
+instance : SemilatticeSup DepSet := inferInstance
+instance : OrderBot DepSet := inferInstance
+
+lemma join_eq_sup (φ₁ φ₂ : DepSet) : join φ₁ φ₂ = φ₁ ⊔ φ₂ := rfl
+lemma le_iff_le (φ₁ φ₂ : DepSet) : le φ₁ φ₂ ↔ φ₁ ≤ φ₂ := Iff.rfl
+lemma empty_eq_bot : empty = (⊥ : DepSet) := rfl
+
+end DepSet
+
+end IATO.V7

--- a/scripts/run-lean-diagnose-compose.sh
+++ b/scripts/run-lean-diagnose-compose.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/docker/lean-diagnose/docker-compose.yml"
+
+if command -v docker >/dev/null 2>&1; then
+  echo "[compose] using docker compose"
+  docker compose -f "$COMPOSE_FILE" up -d --build
+  echo "[compose] lean diagnose UI via reverse proxy: http://127.0.0.1:8088/"
+  echo "[compose] health check: http://127.0.0.1:8088/healthz"
+  exit 0
+fi
+
+if command -v podman >/dev/null 2>&1; then
+  echo "[compose] using podman compose"
+  podman compose -f "$COMPOSE_FILE" up -d --build
+  echo "[compose] lean diagnose UI via reverse proxy: http://127.0.0.1:8088/"
+  echo "[compose] health check: http://127.0.0.1:8088/healthz"
+  exit 0
+fi
+
+echo "[compose] neither docker nor podman is installed"
+exit 127

--- a/scripts/setup-lean-ci-deps.sh
+++ b/scripts/setup-lean-ci-deps.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Lean/Lake tooling for CI and local verification.
+#
+# Usage:
+#   ./scripts/setup-lean-ci-deps.sh
+#   ./scripts/setup-lean-ci-deps.sh --check
+#
+# Optional environment variables:
+#   ELAN_INIT_URL=https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh
+#   LEAN_TOOLCHAIN=stable
+#   INSTALL_RETRIES=2
+#   HTTP_PROXY / HTTPS_PROXY / ALL_PROXY
+
+CHECK_ONLY=0
+if [[ "${1:-}" == "--check" ]]; then
+  CHECK_ONLY=1
+fi
+
+INSTALL_RETRIES="${INSTALL_RETRIES:-2}"
+ELAN_INIT_URL="${ELAN_INIT_URL:-https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh}"
+LEAN_TOOLCHAIN="${LEAN_TOOLCHAIN:-stable}"
+
+have_cmd() { command -v "$1" >/dev/null 2>&1; }
+
+retry() {
+  local attempt=1
+  local max=$((INSTALL_RETRIES + 1))
+  until "$@"; do
+    if (( attempt >= max )); then
+      echo "[retry] command failed after $attempt attempt(s): $*"
+      return 1
+    fi
+    attempt=$((attempt + 1))
+    echo "[retry] retrying ($attempt/$max): $*"
+    sleep 1
+  done
+}
+
+print_state() {
+  echo "[state] elan: $(command -v elan || echo missing)"
+  echo "[state] lean: $(command -v lean || echo missing)"
+  echo "[state] lake: $(command -v lake || echo missing)"
+}
+
+if [[ "$CHECK_ONLY" -eq 1 ]]; then
+  print_state
+  if have_cmd lean && have_cmd lake; then
+    exit 0
+  fi
+  exit 1
+fi
+
+if have_cmd lean && have_cmd lake; then
+  echo "[setup] lean and lake already installed"
+  print_state
+  exit 0
+fi
+
+if ! have_cmd curl && ! have_cmd wget; then
+  echo "[setup] missing curl/wget; cannot bootstrap elan"
+  print_state
+  exit 2
+fi
+
+tmpfile="$(mktemp)"
+cleanup() { rm -f "$tmpfile"; }
+trap cleanup EXIT
+
+echo "[setup] downloading elan installer from: $ELAN_INIT_URL"
+if have_cmd curl; then
+  retry curl -fsSL "$ELAN_INIT_URL" -o "$tmpfile"
+else
+  retry wget -qO "$tmpfile" "$ELAN_INIT_URL"
+fi
+
+echo "[setup] running elan installer"
+sh "$tmpfile" -y --default-toolchain "$LEAN_TOOLCHAIN"
+
+# shellcheck disable=SC1091
+if [[ -f "$HOME/.elan/env" ]]; then
+  source "$HOME/.elan/env"
+else
+  export PATH="$HOME/.elan/bin:$PATH"
+fi
+
+if ! have_cmd lean || ! have_cmd lake; then
+  echo "[setup] elan installed but lean/lake not found on PATH"
+  print_state
+  exit 3
+fi
+
+echo "[setup] lean toolchain details"
+lean --version
+lake --version
+print_state


### PR DESCRIPTION
### Motivation

- Provide a lightweight local compose stack to run Lean diagnostic scans periodically and serve reports via a reverse proxy.  
- Add a convenience script to start the compose stack using either `docker` or `podman`.  
- Add a helper script to bootstrap Lean/Lake tooling for CI and local verification.  
- Replace the previous `IATO_V7_Scaffold` import with a new `DepSet` abstraction using `Finset` in `IATO.V7` to model dependency variables and lattice operations.

### Description

- Added `docker/lean-diagnose` compose stack including `docker-compose.yml`, an Nginx reverse-proxy config at `reverse-proxy/default.conf`, and a usage `README.md` to run a background `lean-diagnose` job, a simple Python HTTP server, and a proxy exposing port `8088`.  
- Implemented `scripts/run-lean-diagnose-compose.sh` which starts the compose stack with `docker` or `podman` and prints access URLs.  
- Implemented `scripts/setup-lean-ci-deps.sh` to download and run the `elan` installer (configurable via environment variables) and ensure `lean`/`lake` are available for CI/local checks.  
- Added `formal/lean/IATO/V7.lean` which defines `DepVar`, `DepSet` as a `Finset DepVar`, join/empty/ordering operations, some lemmas, and instances (`PartialOrder`, `SemilatticeSup`, `OrderBot`) replacing the prior scaffold import.  
- Added `docker/lean-diagnose/README.md` documenting how to run and stop the compose stack and which endpoints are available.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a14ae533308328a27dfd692e828111)