### PR TITLE
Add canonical CI architecture scripts and bootstrap behavior controls

### DIFF
--- a/ci/tools/CONTRIBUTING.md
+++ b/ci/tools/CONTRIBUTING.md
@@ -21,3 +21,20 @@ Changelog utilities are now centralized in:
 - `changelog/scripts/`
 
 Legacy files under `bin/` now forward to this location for compatibility.
+
+### Bootstrap behavior controls
+
+The canonical bootstrap script supports optional strictness and worker package installation:
+
+- `BOOTSTRAP_STRICT=1` (or `--strict`): fail immediately when dependency installation fails.
+- `BOOTSTRAP_INSTALL_WORKER_PACKAGES=1` (or `--install-worker-packages`): ensure worker prerequisites (`git`, `curl`, `unzip`, `jq`) are installed before Python bootstrap.
+
+These environment variables are honored when running `ci/tools/run_all_checks.sh`.
+
+Additional container/shell integration controls:
+
+- `BOOTSTRAP_INSTALL_CONTAINER_PACKAGES=1` (or `--install-container-packages`): try to install `docker` and `podman` commands on workers.
+- `BOOTSTRAP_CONTAINER_RUNTIME=<docker|podman|auto>` (or `--container-runtime`): select preferred runtime for integration output.
+- `BOOTSTRAP_SHELL=<bash|sh|auto>` (or `--shell`): select preferred shell for integration output.
+- `BOOTSTRAP_RUNTIME_ENV_FILE=<path>`: output file for discovered shell/runtime exports (default: `ci/tools/.env.runtime`).
+

--- a/scripts/cli/architecture/bootstrap_env.sh
+++ b/scripts/cli/architecture/bootstrap_env.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STRICT_MODE="${BOOTSTRAP_STRICT:-0}"
+INSTALL_WORKER_PACKAGES="${BOOTSTRAP_INSTALL_WORKER_PACKAGES:-0}"
+INSTALL_CONTAINER_PACKAGES="${BOOTSTRAP_INSTALL_CONTAINER_PACKAGES:-0}"
+PREFERRED_RUNTIME="${BOOTSTRAP_CONTAINER_RUNTIME:-auto}"
+PREFERRED_SHELL="${BOOTSTRAP_SHELL:-auto}"
+RUNTIME_ENV_FILE="${BOOTSTRAP_RUNTIME_ENV_FILE:-ci/tools/.env.runtime}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --strict)
+      STRICT_MODE=1
+      ;;
+    --install-worker-packages)
+      INSTALL_WORKER_PACKAGES=1
+      ;;
+    --install-container-packages)
+      INSTALL_CONTAINER_PACKAGES=1
+      ;;
+    --container-runtime)
+      shift
+      PREFERRED_RUNTIME="${1:-auto}"
+      ;;
+    --shell)
+      shift
+      PREFERRED_SHELL="${1:-auto}"
+      ;;
+    *)
+      echo "[bootstrap_env][error] unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+log() { echo "[bootstrap_env] $*"; }
+warn() { echo "[bootstrap_env][warn] $*" >&2; }
+
+run_with_log() {
+  local label="$1"
+  local cmd="$2"
+  local log_file
+  log_file="$(mktemp)"
+
+  if eval "$cmd" >"$log_file" 2>&1; then
+    rm -f "$log_file"
+    return 0
+  fi
+
+  warn "${label} failed"
+  warn "recent output:"
+  tail -n 20 "$log_file" | sed 's/^/[bootstrap_env][detail] /'
+  rm -f "$log_file"
+
+  if [[ "$STRICT_MODE" == "1" ]]; then
+    warn "strict mode enabled; failing bootstrap"
+    return 1
+  fi
+
+  warn "continuing without failing (set BOOTSTRAP_STRICT=1 to enforce)"
+  return 0
+}
+
+ensure_packages() {
+  local kind="$1"
+  shift
+  local required=("$@")
+  local missing=()
+
+  for pkg in "${required[@]}"; do
+    command -v "$pkg" >/dev/null 2>&1 || missing+=("$pkg")
+  done
+
+  if [[ ${#missing[@]} -eq 0 ]]; then
+    log "${kind} prerequisites already satisfied"
+    return 0
+  fi
+
+  warn "missing ${kind} packages: ${missing[*]}"
+
+  if command -v apt-get >/dev/null 2>&1; then
+    local installer="apt-get"
+    local install_targets=()
+    if [[ "${EUID:-$(id -u)}" -ne 0 ]] && command -v sudo >/dev/null 2>&1; then
+      installer="sudo apt-get"
+    fi
+
+    for item in "${missing[@]}"; do
+      if [[ "$item" == "docker" ]]; then
+        install_targets+=("docker.io")
+      else
+        install_targets+=("$item")
+      fi
+    done
+
+    run_with_log "apt update" "$installer update"
+    run_with_log "apt install" "$installer install -y ${install_targets[*]}"
+    return 0
+  fi
+
+  if command -v yum >/dev/null 2>&1; then
+    local installer="yum"
+    local install_targets=()
+    if [[ "${EUID:-$(id -u)}" -ne 0 ]] && command -v sudo >/dev/null 2>&1; then
+      installer="sudo yum"
+    fi
+
+    for item in "${missing[@]}"; do
+      if [[ "$item" == "docker" ]]; then
+        install_targets+=("docker-ce")
+      else
+        install_targets+=("$item")
+      fi
+    done
+
+    run_with_log "yum install" "$installer install -y ${install_targets[*]}"
+    return 0
+  fi
+
+  warn "no supported package manager detected; install missing packages manually"
+  [[ "$STRICT_MODE" == "1" ]] && return 1 || return 0
+}
+
+resolve_shell() {
+  if [[ "$PREFERRED_SHELL" != "auto" ]]; then
+    if command -v "$PREFERRED_SHELL" >/dev/null 2>&1; then
+      echo "$PREFERRED_SHELL"
+      return 0
+    fi
+    warn "requested shell '$PREFERRED_SHELL' is unavailable"
+    [[ "$STRICT_MODE" == "1" ]] && return 1
+  fi
+
+  if command -v bash >/dev/null 2>&1; then
+    echo "bash"
+    return 0
+  fi
+  if command -v sh >/dev/null 2>&1; then
+    echo "sh"
+    return 0
+  fi
+
+  warn "no compatible shell found"
+  [[ "$STRICT_MODE" == "1" ]] && return 1 || { echo "none"; return 0; }
+}
+
+resolve_runtime() {
+  if [[ "$PREFERRED_RUNTIME" != "auto" ]]; then
+    if command -v "$PREFERRED_RUNTIME" >/dev/null 2>&1; then
+      echo "$PREFERRED_RUNTIME"
+      return 0
+    fi
+    warn "requested runtime '$PREFERRED_RUNTIME' is unavailable"
+    [[ "$STRICT_MODE" == "1" ]] && return 1
+  fi
+
+  if command -v docker >/dev/null 2>&1; then
+    echo "docker"
+    return 0
+  fi
+  if command -v podman >/dev/null 2>&1; then
+    echo "podman"
+    return 0
+  fi
+
+  warn "no container runtime found (docker/podman)"
+  [[ "$STRICT_MODE" == "1" ]] && return 1 || { echo "none"; return 0; }
+}
+
+if [[ "$INSTALL_WORKER_PACKAGES" == "1" ]]; then
+  log "installing worker system packages"
+  ensure_packages "worker" git curl unzip jq
+fi
+
+if [[ "$INSTALL_CONTAINER_PACKAGES" == "1" ]]; then
+  log "installing container runtime packages"
+  ensure_packages "container" docker podman
+fi
+
+SELECTED_SHELL="$(resolve_shell)"
+SELECTED_RUNTIME="$(resolve_runtime)"
+
+mkdir -p "$(dirname "$RUNTIME_ENV_FILE")"
+cat > "$RUNTIME_ENV_FILE" <<RUNTIME_ENV
+BOOTSTRAP_SELECTED_SHELL=${SELECTED_SHELL}
+BOOTSTRAP_SELECTED_CONTAINER_RUNTIME=${SELECTED_RUNTIME}
+RUNTIME_ENV
+log "wrote runtime integration env file: $RUNTIME_ENV_FILE"
+
+if command -v conda >/dev/null 2>&1; then
+  log "conda detected; ensuring testenv exists"
+  run_with_log "conda create testenv" "conda create -y -n testenv python=3.11"
+
+  log "installing baseline Python tooling into conda env"
+  run_with_log "conda pip upgrade" "conda run -n testenv python -m pip install --disable-pip-version-check --upgrade pip"
+  run_with_log "conda package bootstrap" "conda run -n testenv python -m pip install --disable-pip-version-check -e .[test] flake8"
+  log "conda environment bootstrap complete"
+else
+  log "conda not found; bootstrapping with current interpreter"
+  run_with_log "pip upgrade" "python3 -m pip install --disable-pip-version-check --upgrade pip"
+  run_with_log "package bootstrap" "python3 -m pip install --disable-pip-version-check -e .[test] flake8"
+  log "fallback bootstrap complete"
+fi

--- a/scripts/cli/architecture/lint.sh
+++ b/scripts/cli/architecture/lint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+log() { echo "[lint] $*"; }
+
+if command -v flake8 >/dev/null 2>&1; then
+  log "running flake8 against src tests ci/tools"
+  flake8 "$REPO_ROOT/src" "$REPO_ROOT/tests" "$REPO_ROOT/ci/tools"
+  log "flake8 completed successfully"
+  exit 0
+fi
+
+log "flake8 not found; running syntax-only fallback"
+python3 -m compileall -q "$REPO_ROOT/src" "$REPO_ROOT/tests" "$REPO_ROOT/ci/tools"
+log "syntax-only fallback completed successfully"

--- a/scripts/cli/architecture/run_all_checks.sh
+++ b/scripts/cli/architecture/run_all_checks.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+log() { echo "[run_all_checks] $*"; }
+
+run_step() {
+  local step_name="$1"
+  local step_cmd="$2"
+
+  log "starting: ${step_name}"
+  if eval "$step_cmd"; then
+    log "completed: ${step_name}"
+  else
+    local exit_code=$?
+    log "failed: ${step_name} (exit ${exit_code})"
+    return "$exit_code"
+  fi
+}
+
+bootstrap_args=()
+if [[ "${BOOTSTRAP_INSTALL_WORKER_PACKAGES:-0}" == "1" ]]; then
+  bootstrap_args+=("--install-worker-packages")
+fi
+if [[ "${BOOTSTRAP_INSTALL_CONTAINER_PACKAGES:-0}" == "1" ]]; then
+  bootstrap_args+=("--install-container-packages")
+fi
+if [[ "${BOOTSTRAP_STRICT:-0}" == "1" ]]; then
+  bootstrap_args+=("--strict")
+fi
+if [[ -n "${BOOTSTRAP_CONTAINER_RUNTIME:-}" ]]; then
+  bootstrap_args+=("--container-runtime" "${BOOTSTRAP_CONTAINER_RUNTIME}")
+fi
+if [[ -n "${BOOTSTRAP_SHELL:-}" ]]; then
+  bootstrap_args+=("--shell" "${BOOTSTRAP_SHELL}")
+fi
+
+run_step "verify environment" "bash '$SCRIPT_DIR/verify_environment.sh'"
+run_step "bootstrap environment" "bash '$SCRIPT_DIR/bootstrap_env.sh' ${bootstrap_args[*]}"
+run_step "verify imports" "python3 '$SCRIPT_DIR/verify_imports.py'"
+run_step "lint" "bash '$SCRIPT_DIR/lint.sh'"
+
+log "all checks passed"

--- a/scripts/cli/architecture/verify_environment.sh
+++ b/scripts/cli/architecture/verify_environment.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+required_tools=(python3 git openssl)
+optional_tools=(conda flake8 docker podman)
+shell_candidates=(bash sh)
+missing_required=()
+
+log() { echo "[verify_environment] $*"; }
+
+for tool in "${required_tools[@]}"; do
+  if command -v "$tool" >/dev/null 2>&1; then
+    log "found required tool: $tool"
+  else
+    log "missing required tool: $tool"
+    missing_required+=("$tool")
+  fi
+done
+
+for tool in "${optional_tools[@]}"; do
+  if command -v "$tool" >/dev/null 2>&1; then
+    log "found optional tool: $tool"
+  else
+    log "optional tool not found: $tool"
+  fi
+done
+
+runtime="none"
+if command -v docker >/dev/null 2>&1; then
+  runtime="docker"
+elif command -v podman >/dev/null 2>&1; then
+  runtime="podman"
+fi
+log "selected container runtime: $runtime"
+
+selected_shell="none"
+for candidate in "${shell_candidates[@]}"; do
+  if command -v "$candidate" >/dev/null 2>&1; then
+    selected_shell="$candidate"
+    break
+  fi
+done
+log "selected shell: $selected_shell"
+
+if [[ ${#missing_required[@]} -gt 0 ]]; then
+  log "error: required tools missing -> ${missing_required[*]}"
+  exit 1
+fi
+
+python3 --version
+log "environment verification complete"

--- a/scripts/cli/architecture/verify_imports.py
+++ b/scripts/cli/architecture/verify_imports.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Validate required Python imports with actionable error messages."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+REQUIRED_IMPORTS = {
+    "boto3": "pip install boto3",
+    "yaml": "pip install pyyaml",
+    "requests": "pip install requests",
+    "policyuniverse": "pip install policyuniverse",
+}
+
+
+def main() -> int:
+    missing: list[tuple[str, str]] = []
+
+    for module_name, install_hint in REQUIRED_IMPORTS.items():
+        try:
+            importlib.import_module(module_name)
+            print(f"[verify_imports] ok: {module_name}")
+        except Exception as exc:  # noqa: BLE001
+            print(f"[verify_imports] missing: {module_name} ({exc})")
+            missing.append((module_name, install_hint))
+
+    if missing:
+        print("[verify_imports] error: one or more required imports are unavailable")
+        for module_name, install_hint in missing:
+            print(f"  - {module_name}: {install_hint}")
+        return 1
+
+    print("[verify_imports] all required imports available")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation

- Centralize CI validation and bootstrapping into canonical scripts under `scripts/cli/architecture/` and document the architecture in `ci/tools/CONTRIBUTING.md`.
- Provide a robust, optional bootstrap flow that can install worker/container prerequisites, select container runtime and shell, and emit a runtime env file for downstream integration.

### Description

- Add `scripts/cli/architecture/bootstrap_env.sh` which implements strict/fallback bootstrap behavior, optional installation of worker and container packages, runtime/shell resolution, conda-aware Python bootstrap, and writes `ci/tools/.env.runtime` by default.
- Add `scripts/cli/architecture/verify_environment.sh` to validate presence of required/optional host tools and select container runtime and shell.
- Add `scripts/cli/architecture/verify_imports.py` to check critical Python imports with actionable install hints.
- Add `scripts/cli/architecture/lint.sh` that runs `flake8` if available or falls back to a syntax-only check via `python3 -m compileall`.
- Add `scripts/cli/architecture/run_all_checks.sh` to orchestrate environment verification, bootstrap, import checks, and linting, wiring in the new bootstrap environment variables and CLI flags.
- Update `ci/tools/CONTRIBUTING.md` to document the new canonical script locations, changelog script location, and the bootstrap behavior/environment-variable controls.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a21cce068c83288529c82aea338482)