### PR TITLE
Add Lean V7 worker architecture, legacy scanner, and migration assessment pipeline

### DIFF
--- a/IATO_V7/IATO/V7/Architecture.lean
+++ b/IATO_V7/IATO/V7/Architecture.lean
@@ -1,0 +1,48 @@
+import IATO.V7.Scanner
+
+namespace IATO.V7
+
+def referenceArchitecture : List Worker :=
+  [
+    ⟨1, Domain.SecureWorld, {⟨"secure_secret"⟩}⟩,
+    ⟨2, Domain.NormalWorld, {⟨"public_data"⟩}⟩
+  ]
+
+def architectureSecure (workers : List Worker) : Prop :=
+  ∀ i j,
+    i < workers.length →
+    j < workers.length →
+    i ≠ j →
+    Worker.compatible (workers.get ⟨i, by assumption⟩) (workers.get ⟨j, by assumption⟩)
+
+def assessIncompatibility (w : Worker) : String :=
+  if w.domain = Domain.SecureWorld then
+    s!"Worker #{w.id}: split secure dependencies from shared path"
+  else
+    s!"Worker #{w.id}: isolate domain and remove overlapping deps"
+
+def generateMigrationPlan (report : ScanReport) : List String :=
+  let header :=
+    if report.incompatible.isEmpty then
+      ["No migration required; all scanned workers are compatible."]
+    else
+      ["Refactor incompatible workers with dedicated domain/dependency isolation:"]
+  header ++ report.incompatible.map assessIncompatibility
+
+theorem referenceArchitecture_secure : architectureSecure referenceArchitecture := by
+  intro i j hi hj hij
+  have hi' : i = 0 ∨ i = 1 := by omega
+  have hj' : j = 0 ∨ j = 1 := by omega
+  rcases hi' with rfl | rfl
+  · rcases hj' with rfl | rfl
+    · exact (hij rfl).elim
+    · constructor
+      · decide
+      · decide
+  · rcases hj' with rfl | rfl
+    · constructor
+      · decide
+      · decide
+    · exact (hij rfl).elim
+
+end IATO.V7

--- a/IATO_V7/IATO/V7/Scanner.lean
+++ b/IATO_V7/IATO/V7/Scanner.lean
@@ -1,0 +1,57 @@
+import IATO.V7.Worker
+
+namespace IATO.V7
+
+structure LegacyWorker where
+  id : Nat
+  domain : String
+  deps : List String
+  deriving Repr
+
+private def parseDomainNormalized : String → Option Domain
+  | "root" => some Domain.RootWorld
+  | "secure" => some Domain.SecureWorld
+  | "normal" => some Domain.NormalWorld
+  | "peripheral" => some Domain.PeripheralWorld
+  | _ => none
+
+def parseDomain (s : String) : Option Domain :=
+  parseDomainNormalized s.trim.toLower
+
+def parseDeps (xs : List String) : Option DepSet :=
+  if xs.any (fun x => x.trim.isEmpty) then
+    none
+  else
+    some <| (xs.map (fun x => DepVar.mk x.trim)).eraseDups.toFinset
+
+def newReferenceWorker : Worker :=
+  ⟨999, Domain.SecureWorld, {⟨"secure_secret"⟩}⟩
+
+def scanLegacy (lw : LegacyWorker) : Option Worker × Bool :=
+  match parseDomain lw.domain, parseDeps lw.deps with
+  | some d, some φ =>
+    let w : Worker := ⟨lw.id, d, φ⟩
+    (some w, Worker.compatible w newReferenceWorker)
+  | _, _ => (none, false)
+
+structure ScanReport where
+  total : Nat
+  compatible : Nat
+  incompatible : List Worker
+  deriving Repr
+
+def scanAll (lws : List LegacyWorker) : ScanReport := Id.run do
+  let mut compatible := 0
+  let mut incompatible : List Worker := []
+  for lw in lws do
+    let (ow, ok) := scanLegacy lw
+    if let some w := ow then
+      if ok then
+        compatible := compatible + 1
+      else
+        incompatible := incompatible.concat w
+  return ⟨lws.length, compatible, incompatible⟩
+
+theorem scanAll_total_coverage (lws : List LegacyWorker) : (scanAll lws).total = lws.length := rfl
+
+end IATO.V7

--- a/IATO_V7/IATO/V7/Worker.lean
+++ b/IATO_V7/IATO/V7/Worker.lean
@@ -1,0 +1,30 @@
+import IATO.V7.Basic
+
+namespace IATO.V7
+
+inductive Domain where
+  | RootWorld
+  | SecureWorld
+  | NormalWorld
+  | PeripheralWorld
+  deriving DecidableEq, Repr
+
+instance : Inhabited Domain where
+  default := Domain.RootWorld
+
+structure Worker where
+  id : Nat
+  domain : Domain
+  deps : DepSet
+  deriving Repr
+
+instance : Inhabited Worker where
+  default := ⟨0, Domain.RootWorld, ⊥⟩
+
+def Worker.compatible (w1 w2 : Worker) : Prop :=
+  w1.domain ≠ w2.domain ∧ w1.deps ∩ w2.deps = (∅ : DepSet)
+
+def Worker.compose (ws : List Worker) : Worker :=
+  ⟨0, Domain.RootWorld, ws.foldl (fun acc w => acc ⊔ w.deps) ⊥⟩
+
+end IATO.V7

--- a/IATO_V7/IATO_V7.lean
+++ b/IATO_V7/IATO_V7.lean
@@ -1,1 +1,4 @@
 import IATO.V7.Basic
+import IATO.V7.Worker
+import IATO.V7.Scanner
+import IATO.V7.Architecture

--- a/IATO_V7/Main.lean
+++ b/IATO_V7/Main.lean
@@ -1,11 +1,50 @@
-import IATO.V7.Basic
+import IATO.V7.Architecture
+
+open IATO.V7
+
+private def parseLegacyCsvLine? (line : String) : Option LegacyWorker :=
+  match line.splitOn "," with
+  | [idStr, domain, depsRaw] =>
+    match idStr.trim.toNat? with
+    | none => none
+    | some wid =>
+      let deps := depsRaw.splitOn ";" |> List.map String.trim
+      some ⟨wid, domain.trim, deps⟩
+  | _ => none
+
+private def loadLegacyWorkers (path : Option String) : IO (List LegacyWorker) := do
+  match path with
+  | none =>
+    pure
+      [ ⟨1, "Secure", ["secure_secret"]⟩
+      , ⟨2, "Normal", ["public_data"]⟩
+      , ⟨3, "Normal", ["secure_secret", "shared_cache"]⟩
+      ]
+  | some p =>
+    if p.endsWith ".json" then
+      IO.eprintln "JSON parsing is not enabled in this scanner; provide CSV (id,domain,deps) instead."
+      pure []
+    else
+      let txt ← IO.FS.readFile p
+      pure <| (txt.splitOn "\n").filterMap parseLegacyCsvLine?
+
+private def printReport (report : ScanReport) : IO Unit := do
+  IO.println "Worker Scan Report:"
+  IO.println s!"✅ {report.compatible}/{report.total} workers compatible"
+  if report.incompatible.isEmpty then
+    IO.println "❌ 0 workers need migration"
+  else
+    IO.println s!"❌ {report.incompatible.length} workers need migration:"
+    for w in report.incompatible do
+      IO.println s!"  - Worker #{w.id}: domain={repr w.domain}, deps={w.deps.toList.map DepVar.name}"
 
 
-def main : IO Unit := do
-  let α : IATO.V7.DepVar := ⟨"α"⟩
-  let φ₁ : IATO.V7.DepSet := {α}
-  let φ₂ : IATO.V7.DepSet := ∅
+def main (args : List String) : IO Unit := do
+  let workers ← loadLegacyWorkers args.head?
+  let report := scanAll workers
+  let plan := generateMigrationPlan report
 
-  IO.println s!"φ₁ = {φ₁}"
-  IO.println s!"φ₁ ≤ φ₁: {φ₁ ≤ φ₁}"
-  IO.println s!"φ₁ ⊔ φ₂ = {φ₁ ⊔ φ₂}"
+  printReport report
+  IO.println "Migration plan:"
+  for (idx, item) in plan.enum do
+    IO.println s!"  {idx + 1}. {item}"

--- a/IATO_V7/Test/Worker.lean
+++ b/IATO_V7/Test/Worker.lean
@@ -1,0 +1,27 @@
+import IATO.V7.Architecture
+
+open IATO.V7
+
+private def wSecure : Worker := ⟨10, Domain.SecureWorld, {⟨"secure_secret"⟩}⟩
+private def wNormal : Worker := ⟨11, Domain.NormalWorld, {⟨"public_data"⟩}⟩
+private def wConflict : Worker := ⟨12, Domain.NormalWorld, {⟨"secure_secret"⟩}⟩
+
+def test_worker_compatible : Bool :=
+  decide (Worker.compatible wSecure wNormal)
+
+def test_legacy_scan : Bool :=
+  let lw : LegacyWorker := ⟨21, "Normal", ["public_data"]⟩
+  let (_, ok) := scanLegacy lw
+  ok
+
+def test_architecture_secure : Bool :=
+  decide (architectureSecure referenceArchitecture)
+
+
+def main : IO Unit := do
+  IO.println s!"test_worker_compatible = {test_worker_compatible}"
+  IO.println s!"test_legacy_scan = {test_legacy_scan}"
+  IO.println s!"test_architecture_secure = {test_architecture_secure}"
+
+  if !(test_worker_compatible && test_legacy_scan && test_architecture_secure) then
+    throw <| IO.userError "Worker test suite failed"

--- a/IATO_V7/lakefile.lean
+++ b/IATO_V7/lakefile.lean
@@ -14,26 +14,42 @@ lean_lib «IATO_V7» where
 lean_exe «IATO_V7» where
   root := `Main
 
-lean_exe «test» where
+lean_exe «worker-scan» where
+  root := `Main
+
+lean_exe «test-basic» where
   root := `Test.Basic
+
+lean_exe «test-worker» where
+  root := `Test.Worker
 
 lean_exe «cache» where
   root := `Cache
 
 script test do
-  let out ← IO.Process.output {
+  let buildOut ← IO.Process.output {
     cmd := "lake"
-    args := # ["build", "test"]
+    args := # ["build", "test-basic", "test-worker"]
   }
-  IO.print out.stdout
-  if out.exitCode != 0 then
-    IO.eprintln out.stderr
-    return out.exitCode
-  let runOut ← IO.Process.output {
+  IO.print buildOut.stdout
+  if buildOut.exitCode != 0 then
+    IO.eprintln buildOut.stderr
+    return buildOut.exitCode
+
+  let runBasic ← IO.Process.output {
     cmd := "lake"
-    args := #["exe", "test"]
+    args := #["exe", "test-basic"]
   }
-  IO.print runOut.stdout
-  if runOut.exitCode != 0 then
-    IO.eprintln runOut.stderr
-  return runOut.exitCode
+  IO.print runBasic.stdout
+  if runBasic.exitCode != 0 then
+    IO.eprintln runBasic.stderr
+    return runBasic.exitCode
+
+  let runWorker ← IO.Process.output {
+    cmd := "lake"
+    args := #["exe", "test-worker"]
+  }
+  IO.print runWorker.stdout
+  if runWorker.exitCode != 0 then
+    IO.eprintln runWorker.stderr
+  return runWorker.exitCode


### PR DESCRIPTION
### Motivation
- Provide a formal, machine-checkable worker model to represent identities, domains, and dependency footprints for migration and compatibility analysis.
- Be able to scan legacy worker descriptions (CSV) and map them into the formal model for automated compatibility checks against a reference architecture.
- Generate actionable migration recommendations and integrate the pipeline into the existing `IATO_V7` executable/test layout.

### Description
- Added `IATO/V7/Worker.lean` which defines `Domain`, the `Worker` structure, `Worker.compatible`, and `Worker.compose` using the existing `DepSet` lattice operations.
- Added `IATO/V7/Scanner.lean` which defines `LegacyWorker`, `parseDomain`, `parseDeps`, `scanLegacy`, aggregated `ScanReport`, `scanAll`, and the theorem `scanAll_total_coverage` that the scanner covers all inputs.
- Added `IATO/V7/Architecture.lean` which defines `referenceArchitecture`, the global non-interference predicate `architectureSecure`, `generateMigrationPlan` (and `assessIncompatibility`), and the proof `referenceArchitecture_secure` that the reference architecture satisfies the invariant.
- Updated `Main.lean` to implement a simple CLI (`CSV`-based) loader, run the scanner, print a human-friendly `ScanReport` and migration plan, added `IATO_V7/Test/Worker.lean` with runtime checks for compatibility/scan/architecture, and updated `lakefile.lean` + `IATO_V7.lean` to expose new modules and add `worker-scan` and `test-worker` executables.

### Testing
- Attempted to build the `IATO_V7` package with `cd IATO_V7 && lake build`, but the environment lacks the `lake` tool so the build could not be executed (`bash: command not found: lake`).
- A `lake test` script and the `test-worker` executable are provided in the `lakefile.lean` and `IATO_V7/Test/Worker.lean` to run the checks (`test_worker_compatible`, `test_legacy_scan`, `test_architecture_secure`) in an environment with `lake` installed; these were not executed here due to the missing tool.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a36618c548832f836cfb0ff870707d)