### PR TITLE
Add ebpf/netflow-sidecar/go.sum to resolve PR #120 conflict

### DIFF
--- a/ebpf/netflow-sidecar/go.sum
+++ b/ebpf/netflow-sidecar/go.sum
@@ -1,0 +1,1 @@
+github.com/aquasecurity/libbpfgo v0.8.0-libbpf-1.5/go.mod h1:HB2DYWHuMraOB0IFcfjL8tsxN8TcFOdWKTrNqnHrTrs=


### PR DESCRIPTION
### Motivation
- Track the missing Go checksum for the netflow sidecar by adding `ebpf/netflow-sidecar/go.sum` so the repository `go.mod` metadata is complete and the merge conflict state is resolved.

### Description
- Add `ebpf/netflow-sidecar/go.sum` containing the checksum entry for `github.com/aquasecurity/libbpfgo v0.8.0-libbpf-1.5/go.mod` to align module metadata with `ebpf/netflow-sidecar/go.mod`.

### Testing
- Ran `cd ebpf/netflow-sidecar && go test ./...` and `go mod tidy`, but dependency fetching from `proxy.golang.org` failed with HTTP 403 in this environment so module resolution and tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3c4d066d0832f97882609e40494b5)