### PR TITLE
Add worker setup helper script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ cd IATO_V7 && lake test
 # SOC2 CC6.6 / PI1.3: scan legacy workers for change-risk and input issues
 python3 scripts/scan_workers.py data/legacy_workers.csv
 
+# Setup a new worker scaffold for migration planning
+./scripts/setup_worker.sh worker3 rme alpha|beta
+
 # ISM 0457-0460: run migration workflow for FEAT_RME alignment
 ./scripts/migrate.sh
 

--- a/scripts/setup_worker.sh
+++ b/scripts/setup_worker.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+  echo "Usage: $0 <worker_id> <world:rme|normal> [deps_pipe_separated]" >&2
+  exit 1
+fi
+
+worker_id="$1"
+world="$2"
+deps="${3:-}"
+
+case "$world" in
+  rme|normal) ;;
+  *)
+    echo "Invalid world '$world'. Expected 'rme' or 'normal'." >&2
+    exit 1
+    ;;
+esac
+
+if [[ ! "$worker_id" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+  echo "Invalid worker_id '$worker_id'. Use letters, numbers, dot, underscore, or dash." >&2
+  exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+worker_dir="$repo_root/workers/new/$worker_id"
+worker_file="$worker_dir/worker.json"
+
+mkdir -p "$worker_dir"
+
+cat > "$worker_file" <<JSON
+{
+  "id": "$worker_id",
+  "world": "$world",
+  "deps": "${deps}",
+  "architecture": "IATO-V7",
+  "source": "scripts/setup_worker.sh"
+}
+JSON
+
+echo "Created worker scaffold: $worker_file"

--- a/workers/new/README.md
+++ b/workers/new/README.md
@@ -1,3 +1,20 @@
 # New Workers
 
 IATO-V7-compatible worker outputs are written here.
+
+## Setup a new worker
+
+Use the repository helper script to scaffold a worker manifest:
+
+```bash
+./scripts/setup_worker.sh <worker_id> <world:rme|normal> [deps_pipe_separated]
+```
+
+Example:
+
+```bash
+./scripts/setup_worker.sh worker3 rme alpha|beta
+```
+
+This creates `workers/new/<worker_id>/worker.json`.
+


### PR DESCRIPTION
### Motivation

- Provide a simple, auditable way to scaffold worker manifests for migration planning so teams can create `workers/new/<worker_id>/worker.json` consistently.
- Validate inputs early (argument count, allowed `worker_id` characters, and `world` value) to avoid malformed migration inputs.

### Description

- Add `scripts/setup_worker.sh`, an executable helper that creates `workers/new/<worker_id>/worker.json` and enforces `world` to be `rme` or `normal` and a safe `worker_id` format.
- The script writes a minimal manifest including `id`, `world`, `deps`, `architecture: "IATO-V7"`, and `source` fields.
- Update `workers/new/README.md` to document usage and include an example `./scripts/setup_worker.sh worker3 rme alpha|beta`.
- Update the root `README.md` to surface the worker scaffold example in the compliance commands block.

### Testing

- Ran `./scripts/setup_worker.sh test_worker rme 'alpha|beta'` and inspected `workers/new/test_worker/worker.json`, which was created with the expected JSON shape (success).
- Ran `./scripts/setup_worker.sh demo normal ''` and validated the produced JSON via `python3 -m json.tool`, which succeeded (success).
- Ran `./scripts/setup_worker.sh demo invalid` to verify the script exits with an error for an invalid `world` value (exit code 1, expected failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3c892c0c0832fb3eadaa4dcd5a962)