### PR TITLE
Add README conflict producer worker and union merge policy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto-merge README updates by concatenating both sides to reduce false conflicts.
+README.md merge=union

--- a/workers/modern/README.md
+++ b/workers/modern/README.md
@@ -18,3 +18,8 @@ Example:
 
 This creates `workers/modern/<worker_id>/worker.json`.
 
+## Predefined producer worker
+
+`workers/modern/readme_conflict_producer/worker.json` defines a producer worker that marks `README.md`
+changes as non-blocking by using the Git union merge policy (`README.md merge=union`).
+This worker explicitly does not require environment variables.

--- a/workers/modern/readme_conflict_producer/worker.json
+++ b/workers/modern/readme_conflict_producer/worker.json
@@ -1,0 +1,14 @@
+{
+  "id": "readme_conflict_producer",
+  "world": "normal",
+  "deps": "git",
+  "architecture": "IATO-V7",
+  "source": "manual",
+  "role": "producer",
+  "requires_env": false,
+  "conflict_policy": {
+    "path": "README.md",
+    "strategy": "merge=union",
+    "statement": "README.md text updates are treated as non-blocking content merges and do not require environment variables."
+  }
+}


### PR DESCRIPTION
### Motivation
- Make README-only edits non-blocking during merges and provide a producer worker that explicitly does not require environment variables to assert README statements are non-conflicting.

### Description
- Add `.gitattributes` with `README.md merge=union` to auto-merge README text edits.
- Add `workers/modern/readme_conflict_producer/worker.json` defining a `producer` worker with `"requires_env": false` and a `conflict_policy` for `README.md` using the union strategy.
- Update `workers/modern/README.md` to document the predefined producer worker and the non-env policy.

### Testing
- Ran `git check-attr merge -- README.md` which returned `union` and validated the attribute configuration.
- Validated `workers/modern/readme_conflict_producer/worker.json` with `python3 -m json.tool` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3edbb3dc0832fbaa205b621b57d1f)