### PR TITLE
Normalize CI proxy env, add CI setup scripts, Kubernetes fallback job, and improve Lean build steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,6 @@ name: build
 on:
   workflow_dispatch:
 
-env:
-  INSTALL_RETRIES: "3"
-  LEAN_TOOLCHAIN: stable
-
 jobs:
   package-check:
     runs-on: ubuntu-latest
@@ -16,11 +12,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Normalize CI env variables
-        run: ../scripts/normalize_ci_env.sh
+      - name: Install elan
+        run: |
+          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
-      - name: Setup Lean CI dependencies
-        run: ../scripts/setup-lean-ci-deps.sh
+      - name: Install Lake
+        run: |
+          lean install lake
+          export PATH=$HOME/.lake/bin:$PATH
+          echo "$HOME/.lake/bin" >> "$GITHUB_PATH"
 
       - name: Build Lean package
         run: lake build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,14 +3,24 @@ name: build
 on:
   workflow_dispatch:
 
+env:
+  INSTALL_RETRIES: "3"
+  LEAN_TOOLCHAIN: stable
+
 jobs:
   package-check:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: lean
     steps:
       - uses: actions/checkout@v4
-      - name: Install elan
-        run: |
-          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
-          echo "$HOME/.elan/bin" >> $GITHUB_PATH
+
+      - name: Normalize CI env variables
+        run: ../scripts/normalize_ci_env.sh
+
+      - name: Setup Lean CI dependencies
+        run: ../scripts/setup-lean-ci-deps.sh
+
       - name: Build Lean package
-        run: cd lean && lake build
+        run: lake build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: build
 on:
   workflow_dispatch:
 
+env:
+  INSTALL_RETRIES: "3"
+
 jobs:
   package-check:
     runs-on: ubuntu-latest
@@ -11,6 +14,9 @@ jobs:
         working-directory: lean
     steps:
       - uses: actions/checkout@v4
+
+      - name: Normalize CI env variables
+        run: ../scripts/normalize_ci_env.sh
 
       - name: Install elan
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,11 +4,17 @@ on:
   push:
   pull_request:
 
+env:
+  INSTALL_RETRIES: "3"
+
 jobs:
   lean-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Normalize CI env variables
+        run: ./scripts/normalize_ci_env.sh
 
       - name: Install elan
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,21 +4,22 @@ on:
   push:
   pull_request:
 
-env:
-  INSTALL_RETRIES: "3"
-  LEAN_TOOLCHAIN: stable
-
 jobs:
   lean-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Normalize CI env variables
-        run: ./scripts/normalize_ci_env.sh
+      - name: Install elan
+        run: |
+          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
-      - name: Setup Lean CI dependencies
-        run: ./scripts/setup-lean-ci-deps.sh
+      - name: Install Lake
+        run: |
+          lean install lake
+          export PATH=$HOME/.lake/bin:$PATH
+          echo "$HOME/.lake/bin" >> "$GITHUB_PATH"
 
       - name: Lean build
         run: ./scripts/lake_build.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,14 +4,21 @@ on:
   push:
   pull_request:
 
+env:
+  INSTALL_RETRIES: "3"
+  LEAN_TOOLCHAIN: stable
+
 jobs:
   lean-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install elan
-        run: |
-          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
-          echo "$HOME/.elan/bin" >> $GITHUB_PATH
+
+      - name: Normalize CI env variables
+        run: ./scripts/normalize_ci_env.sh
+
+      - name: Setup Lean CI dependencies
+        run: ./scripts/setup-lean-ci-deps.sh
+
       - name: Lean build
         run: ./scripts/lake_build.sh

--- a/lean/iato_v7/README.md
+++ b/lean/iato_v7/README.md
@@ -80,3 +80,16 @@ Important variables:
 - `PODMAN_USERNS=keep-id` to reduce host/container UID mismatch issues.
 - `PODMAN_SYSTEMD_UNIT=false` to avoid systemd unit expectations in simple sessions.
 - `COMPOSE_DOCKER_CLI_BUILD=1` for compatible compose build behavior.
+
+## Kubernetes fallback job (proxy-conflict mitigation)
+
+For environments where local container networking/proxy behavior differs from Podman,
+you can run the same build as a standard Kubernetes Job:
+
+```bash
+kubectl apply -f k8s-build-job.yaml
+kubectl logs -f job/iato-v7-lean-build
+```
+
+The job includes `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` fields so cluster-level
+proxy values can be managed consistently.

--- a/lean/iato_v7/README.md
+++ b/lean/iato_v7/README.md
@@ -93,3 +93,16 @@ kubectl logs -f job/iato-v7-lean-build
 
 The job includes `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` fields so cluster-level
 proxy values can be managed consistently.
+
+
+## Fail-forward Defensive DevOps strategy
+
+This project intentionally prioritizes availability and execution over architectural purity:
+
+- **Normalization as a Filter**: `scripts/normalize_ci_env.sh` acts as the source of truth for CI proxy state.
+  It maps upper/lower-case proxy variables and writes deterministic values to `GITHUB_ENV` so Lean/Lake
+  and container tooling do not inherit host-specific ambiguity.
+- **Podman as the low-cost path**: `podman-compose.yml` is the first, fastest daemonless execution path
+  for terminal-centric workflows.
+- **Kubernetes as the guaranteed path**: `k8s-build-job.yaml` is the fallback when local DNS/proxy
+  interception causes Podman networking mismatches, using cluster-native service discovery and egress policy.

--- a/lean/iato_v7/k8s-build-job.yaml
+++ b/lean/iato_v7/k8s-build-job.yaml
@@ -1,0 +1,37 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: iato-v7-lean-build
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: iato-v7
+          image: docker.io/leanprover/lean4:stable
+          imagePullPolicy: IfNotPresent
+          workingDir: /workspace
+          env:
+            - name: HTTP_PROXY
+              value: ""
+            - name: HTTPS_PROXY
+              value: ""
+            - name: NO_PROXY
+              value: "localhost,127.0.0.1,::1,.svc,.cluster.local"
+          command: ["/bin/sh", "-lc"]
+          args:
+            - >-
+              lake update &&
+              lake build &&
+              lake test &&
+              lake exe cache &&
+              lake aot
+          volumeMounts:
+            - name: workspace
+              mountPath: /workspace
+      volumes:
+        - name: workspace
+          hostPath:
+            path: /workspace
+            type: Directory

--- a/lean/iato_v7/podman-compose.yml
+++ b/lean/iato_v7/podman-compose.yml
@@ -7,6 +7,9 @@ services:
       - LEAN_ABORT_ON_PANIC=${LEAN_ABORT_ON_PANIC:-1}
       - LEAN_PATH=${LEAN_PATH:-/workspace/.lake/packages}
       - LAKE_NO_CACHE=${LAKE_NO_CACHE:-0}
+      - HTTP_PROXY=${HTTP_PROXY:-${http_proxy:-}}
+      - HTTPS_PROXY=${HTTPS_PROXY:-${https_proxy:-}}
+      - NO_PROXY=${NO_PROXY:-${no_proxy:-localhost,127.0.0.1,::1,.svc,.cluster.local}}
       - PODMAN_USERNS=${PODMAN_USERNS:-keep-id}
       - COMPOSE_DOCKER_CLI_BUILD=${COMPOSE_DOCKER_CLI_BUILD:-1}
     volumes:

--- a/scripts/lake_build.sh
+++ b/scripts/lake_build.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cd lean
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT/lean"
 echo "Building IATO-V7 formal verification..."
 lake update
 lake build

--- a/scripts/normalize_ci_env.sh
+++ b/scripts/normalize_ci_env.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Normalize proxy-related environment variables for CI tools and containers.
+# - Mirrors lowercase/uppercase proxy env names
+# - Ensures NO_PROXY includes local loopback defaults
+# - Exports values for subsequent GitHub Actions steps via GITHUB_ENV
+
+first_set() {
+  local v
+  for v in "$@"; do
+    if [[ -n "${!v:-}" ]]; then
+      printf '%s' "${!v}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+HTTP_PROXY_VAL="$(first_set HTTP_PROXY http_proxy || true)"
+HTTPS_PROXY_VAL="$(first_set HTTPS_PROXY https_proxy || true)"
+NO_PROXY_VAL="$(first_set NO_PROXY no_proxy || true)"
+
+DEFAULT_NO_PROXY="localhost,127.0.0.1,::1"
+if [[ -z "$NO_PROXY_VAL" ]]; then
+  NO_PROXY_VAL="$DEFAULT_NO_PROXY"
+elif [[ ",$NO_PROXY_VAL," != *",localhost,"* ]]; then
+  NO_PROXY_VAL="$NO_PROXY_VAL,$DEFAULT_NO_PROXY"
+fi
+
+export HTTP_PROXY="$HTTP_PROXY_VAL"
+export http_proxy="$HTTP_PROXY_VAL"
+export HTTPS_PROXY="$HTTPS_PROXY_VAL"
+export https_proxy="$HTTPS_PROXY_VAL"
+export NO_PROXY="$NO_PROXY_VAL"
+export no_proxy="$NO_PROXY_VAL"
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  {
+    echo "HTTP_PROXY=$HTTP_PROXY"
+    echo "http_proxy=$http_proxy"
+    echo "HTTPS_PROXY=$HTTPS_PROXY"
+    echo "https_proxy=$https_proxy"
+    echo "NO_PROXY=$NO_PROXY"
+    echo "no_proxy=$no_proxy"
+  } >> "$GITHUB_ENV"
+fi
+
+echo "[ci-env] HTTP_PROXY set: $([[ -n "$HTTP_PROXY" ]] && echo yes || echo no)"
+echo "[ci-env] HTTPS_PROXY set: $([[ -n "$HTTPS_PROXY" ]] && echo yes || echo no)"
+echo "[ci-env] NO_PROXY=$NO_PROXY"


### PR DESCRIPTION
### Motivation

- Make CI runs reproducible across environments by normalizing proxy-related environment variables and centralizing Lean setup steps. 
- Reduce per-workflow duplication and flaky elan installs by introducing shared setup scripts and common env defaults. 
- Improve local/container portability for Podman-based builds by propagating proxy settings and documenting environment expectations. 
- Provide a Kubernetes fallback for environments where Podman/container networking or proxy behavior blocks local builds.

### Description

- Added `scripts/normalize_ci_env.sh` to canonicalize `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` (and lowercase variants) and export them to `GITHUB_ENV` for subsequent steps. 
- Updated GitHub Actions workflows (`.github/workflows/build.yml` and `.github/workflows/test.yml`) to set CI-level env defaults (`INSTALL_RETRIES`, `LEAN_TOOLCHAIN`), call the new normalization and setup scripts, and use a Lean-specific working directory default. 
- Replaced inline elan install steps with `Setup Lean CI dependencies` hooks and updated the Lean build invocation to use `./scripts/lake_build.sh`, while improving that script to compute repository paths robustly and run `lake update`, `lake build`, and test builds. 
- Added Podman portability improvements in `lean/iato_v7/podman-compose.yml`, a Kubernetes Job fallback `lean/iato_v7/k8s-build-job.yaml`, and documentation updates to `lean/iato_v7/README.md` describing Podman envs and the Kubernetes fallback.

### Testing

- No automated tests were executed as part of this PR itself. 
- CI workflows were updated so future runs will execute `lake build` and `lake test` via the `package-check` and `lean-test` jobs, respectively, using the new normalization and setup steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a504f27c24832fa55b1d0abde102fd)