### PR TITLE
Fix Lean CI setup and harden lake build script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,14 @@ jobs:
 
       - name: Install Lake
         run: |
-          lean install lake
-          export PATH=$HOME/.lake/bin:$PATH
-          echo "$HOME/.lake/bin" >> "$GITHUB_PATH"
+          elan toolchain install leanprover/lean4:stable
+          elan default leanprover/lean4:stable
+          lake update
+
+      - name: Verify Lean build script
+        run: |
+          test -x ./scripts/lake_build.sh
+          ./scripts/lake_build.sh --help >/dev/null 2>&1 || true
 
       - name: Lean build
         run: ./scripts/lake_build.sh

--- a/scripts/lake_build.sh
+++ b/scripts/lake_build.sh
@@ -1,10 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ "${1:-}" == "--help" ]]; then
+  cat <<'USAGE'
+Usage: scripts/lake_build.sh
+Builds Lean targets from the repository's lean/ project.
+USAGE
+  exit 0
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LEAN_ROOT="$REPO_ROOT/lean"
 
-cd "$REPO_ROOT/lean"
+if [[ ! -f "$LEAN_ROOT/lakefile.lean" ]]; then
+  echo "error: expected Lean project at $LEAN_ROOT (missing lakefile.lean)" >&2
+  exit 1
+fi
+
+cd "$LEAN_ROOT"
 echo "Building IATO-V7 formal verification..."
 lake update
 lake build


### PR DESCRIPTION
### Motivation
- The CI job was failing with Lean help text instead of a real failure, indicating an incorrect Lean/Lake install or an improperly invoked build script.
- The workflow previously used an unsupported `lean install lake` invocation and lacked verification that the build script existed and was executable.

### Description
- Updated `.github/workflows/test.yml` to install the Lean toolchain using `elan toolchain install` and `elan default` and to run `lake update` instead of `lean install lake`.
- Added a `Verify Lean build script` step to the workflow that checks `./scripts/lake_build.sh` is executable and invokes it with `--help` harmlessly.
- Rewrote `scripts/lake_build.sh` to add a `--help` mode, set `LEAN_ROOT` to `REPO_ROOT/lean`, verify that `lean/lakefile.lean` exists with a clear error message, and continue to run `lake update` and `lake build` targets.
- Ensured `scripts/lake_build.sh` is executable and that the CI step uses the validated script path `./scripts/lake_build.sh`.

### Testing
- Ran `bash -n scripts/lake_build.sh` to validate shell syntax and it succeeded.
- Ran `./scripts/lake_build.sh --help` to validate the new help path and it printed usage and exited successfully.
- Ran `test -x scripts/lake_build.sh && echo ok` to confirm the script is executable and it returned `ok`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a50e44fb80832fb86924c9ccc5cc8a)