### PR TITLE
Add Minikube CI proxy worker for Lean build scaffold

### DIFF
--- a/lean/iato_v7/ci-proxy-worker-setup.md
+++ b/lean/iato_v7/ci-proxy-worker-setup.md
@@ -1,0 +1,41 @@
+# CI Proxy Worker setup (Minikube + WSL2 + Windows host)
+
+When you run this, you are essentially creating a "Sidecar" or "Runner" pattern. Because you are using Minikube, keep in mind that the `hostPath` doesn't see your C: drive by default—Minikube runs inside a VM.
+
+## Missing link command (run from Windows terminal)
+
+```powershell
+minikube mount C:\Users\Name\Project:/workspace
+```
+
+## Minikube mount command (with persistence-friendly UID/GID)
+
+```bash
+minikube mount --uid=1000 --gid=1000 C:/Users/Name/Project:/workspace
+```
+
+## Recommended `/etc/wsl.conf`
+
+```ini
+[automount]
+enabled = true
+options = "metadata,umask=22,fmask=11"
+mountFsTab = false
+```
+
+After updating `/etc/wsl.conf`, restart WSL:
+
+```powershell
+wsl --shutdown
+```
+
+Then re-open your WSL shell and re-run the Minikube mount command.
+
+## Apply the CI Proxy worker resources
+
+```bash
+kubectl apply -f lean/iato_v7/k8s-ci-proxy-worker.yaml
+kubectl logs -f job/iato-v7-ci-proxy-worker
+```
+
+The worker loads `lean/iato_v7/k8s-build-job.yaml` as read-only scaffold input, parses the scaffold `args`, and executes them in `/workspace` inside the Lean container.

--- a/lean/iato_v7/k8s-ci-proxy-worker.yaml
+++ b/lean/iato_v7/k8s-ci-proxy-worker.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: lean-cache-pv
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  hostPath:
+    path: /workspace/.ci-cache
+    type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: lean-cache-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: iato-v7-ci-proxy-worker
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      hostNetwork: true
+      restartPolicy: Never
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: ci-proxy
+          image: docker.io/leanprover/lean4:stable
+          imagePullPolicy: IfNotPresent
+          workingDir: /workspace
+          env:
+            - name: HTTP_PROXY
+              value: ""
+            - name: HTTPS_PROXY
+              value: ""
+            - name: NO_PROXY
+              value: "localhost,127.0.0.1,::1,.svc,.cluster.local"
+            - name: SCAFFOLD_FILE
+              value: /config/k8s-build-job.yaml
+          command: ["/bin/sh", "-lc"]
+          args: ["/scripts/run-ci-proxy.sh"]
+          volumeMounts:
+            - name: workspace
+              mountPath: /workspace
+            - name: scaffold
+              mountPath: /config
+              readOnly: true
+            - name: scripts
+              mountPath: /scripts
+              readOnly: true
+            - name: lean-cache
+              mountPath: /home/lean/.elan
+              subPath: elan
+            - name: lean-cache
+              mountPath: /home/lean/.lake
+              subPath: lake
+      volumes:
+        - name: workspace
+          hostPath:
+            path: /workspace
+            type: Directory
+        - name: scaffold
+          hostPath:
+            path: /workspace/lean/iato_v7
+            type: Directory
+        - name: scripts
+          hostPath:
+            path: /workspace/lean/iato_v7
+            type: Directory
+        - name: lean-cache
+          persistentVolumeClaim:
+            claimName: lean-cache-pvc

--- a/lean/iato_v7/run-ci-proxy.sh
+++ b/lean/iato_v7/run-ci-proxy.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env sh
+set -eu
+
+SCAFFOLD_FILE="${SCAFFOLD_FILE:-/config/k8s-build-job.yaml}"
+WORKDIR="${WORKDIR:-/workspace}"
+
+if [ ! -f "$SCAFFOLD_FILE" ]; then
+  echo "Scaffold not found: $SCAFFOLD_FILE" >&2
+  exit 1
+fi
+
+CMD="$(awk '
+  function indent_len(s,   n,i,c) {
+    n=0
+    for (i=1; i<=length(s); i++) {
+      c=substr(s,i,1)
+      if (c == " ") n++
+      else break
+    }
+    return n
+  }
+  {
+    line=$0
+    indent=indent_len(line)
+
+    if (!in_args && line ~ /^[[:space:]]*args:[[:space:]]*$/) {
+      in_args=1
+      args_indent=indent
+      next
+    }
+
+    if (in_args && !capture && line ~ /^[[:space:]]*-[[:space:]]*>-[[:space:]]*$/) {
+      capture=1
+      cmd_indent=indent + 2
+      next
+    }
+
+    if (capture) {
+      if (line ~ /^[[:space:]]*$/) next
+      if (indent < cmd_indent) {
+        capture=0
+        in_args=0
+      } else {
+        sub(/^[[:space:]]+/, "", line)
+        cmd = cmd line " "
+      }
+    }
+  }
+  END { gsub(/[[:space:]]+$/, "", cmd); print cmd }
+' "$SCAFFOLD_FILE")"
+
+if [ -z "$CMD" ]; then
+  echo "Unable to parse scaffold args from $SCAFFOLD_FILE" >&2
+  exit 1
+fi
+
+echo "[ci-proxy] cd $WORKDIR"
+cd "$WORKDIR"
+echo "[ci-proxy] exec: $CMD"
+exec /bin/sh -lc "$CMD"


### PR DESCRIPTION
### Motivation
- Provide a lightweight CI "proxy" runner that bridges a Windows host (Minikube/WSL2) to the existing Lean `Job` scaffold without modifying the scaffold itself. 
- Preserve dependency caches and NTFS/WSL2 permissions so `lake build` doesn't re-download or suffer permission collisions. 
- Ensure the worker can reach host credentials/agents and run with a WSL-friendly UID by adding networking and identity controls.

### Description
- Add `lean/iato_v7/k8s-ci-proxy-worker.yaml` which defines a PV (`lean-cache-pv`) and PVC (`lean-cache-pvc`) for caching `~/.elan` and `~/.lake`, and a wrapper `Job` named `iato-v7-ci-proxy-worker` that sets `hostNetwork: true`, and a `securityContext` with `runAsUser: 1000` and `fsGroup: 1000`, mounts the original scaffold as read-only, and uses a `hostPath` workspace at `/workspace` for Minikube mounts. 
- Add `lean/iato_v7/run-ci-proxy.sh`, a portable shell runner that reads the scaffold `args` block from `k8s-build-job.yaml`, composes the command string, `cd`'s into the mounted `WORKDIR`, and `exec`s the parsed command with `/bin/sh -lc`. 
- Add `lean/iato_v7/ci-proxy-worker-setup.md` documenting the required `minikube mount` commands (including `--uid=1000 --gid=1000`), the recommended `/etc/wsl.conf` snippet enabling `metadata`, and `kubectl` apply/log commands to deploy and monitor the worker. 
- The original scaffold file `lean/iato_v7/k8s-build-job.yaml` is left unchanged and is consumed read-only by the worker.

### Testing
- Validated the YAML `args` extraction using the embedded `awk` logic against `lean/iato_v7/k8s-build-job.yaml` and confirmed it returns the expected command: `lake update && lake build && lake test && lake exe cache && lake aot`. 
- Ran the script guard by executing the runner with a missing scaffold path to confirm it exits with an error, and then ran `SCAFFOLD_FILE=lean/iato_v7/k8s-build-job.yaml WORKDIR=/workspace/Intent-to-Auditable-Trust-Object lean/iato_v7/run-ci-proxy.sh` to confirm the runner `cd`'s to `WORKDIR` and prints/execs the parsed command (handoff behavior depends on the runtime Lean environment). 
- Confirmed created manifests and scripts are present and readable in the repository (no cluster `kubectl apply` was executed as part of automated validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a604e285bc832f8454d68f2570c987)