### PR TITLE
Document Nmap-based orchestrator and add deterministic `config.toml` manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,18 @@ Formal verification bridge from legacy workers to a compliance-ready FEAT_RME mu
 
 ## Executive Summary
 
-IATO-V7 provides a formal, auditable path to move from legacy worker deployments to verified FEAT_RME isolation boundaries. It combines Lean4/mathlib proofs, conflict scanning, and migration workflows to support enterprise security assurance and regulatory evidence production.
+**IĀTŌ‑V7** is a deterministic, configuration-driven transformation and validation engine. Its objective is to transmute raw, real-world data—specifically host-path file systems—into structured, auditable XML artifacts. By enforcing formal logic at the orchestration layer, we ensure reproducibility across SOC environments.
 
-Core capabilities:
-- Prove worker compatibility with non-interference invariants.
-- Detect dependency and domain conflicts in legacy workers.
-- Migrate worker sets into FEAT_RME-aligned multi-world boundaries.
-- Generate mechanized proof artifacts for high-assurance audit review.
+### Architecture: The Nmap Audit Pattern
+
+We have moved away from traditional, labor-intensive file-system parsers. Instead, IĀTŌ‑V7 leverages **Nmap** as a stateless, high-concurrency discovery engine. By repurposing Nmap within a WSL2/Minikube environment, we treat host-path auditing as a canonical state-discovery process.
+
+| Component | Role |
+| --- | --- |
+| **TOML Manifest** | Source of truth for paths, hash expectations, and audit rules. |
+| **Nmap (Orchestrator)** | Executes path discovery and integrity checks via NSE scripts. |
+| **XML Artifacts** | Canonical output format for downstream formal validation. |
+| **IĀTŌ‑V7 Engine** | Consumes XML to validate observed state against the original TOML manifest. |
 
 ## Compliance Coverage
 
@@ -127,14 +132,23 @@ sudo apt update
 sudo apt install -y git curl python3 python3-pip build-essential
 ```
 
-### 3) Install Lean toolchain dependencies
+### 3) Initialize deterministic audit manifest
+
+```bash
+cp config.toml config.local.toml
+# edit config.local.toml and set root_path/targets for your environment
+```
+
+The `config.toml` file is the canonical schema template for IĀTŌ‑V7 path-audit orchestration. It defines all audit targets, expected hashes/ownership, timing profile (`T2`/`T3`), and XML artifact locations.
+
+### 4) Install Lean toolchain dependencies
 
 ```bash
 ./scripts/install-formal-verification-deps.sh
 ./scripts/setup-lean-ci-deps.sh
 ```
 
-### 4) Build + validate
+### 5) Build + validate
 
 ```bash
 # run Lean model tests
@@ -149,7 +163,7 @@ python3 scripts/scan_workers.py data/legacy_workers.csv
 ./scripts/lake_build.sh
 ```
 
-### 5) Target outcome (what success looks like)
+### 6) Target outcome (what success looks like)
 
 - Lean tests complete successfully (`lake test` exits 0).
 - Worker scan writes compatibility/risk output without errors.
@@ -182,6 +196,21 @@ python3 scripts/scan_workers.py data/legacy_workers.csv
 # Build evidence artifacts for audit chains
 ./scripts/lake_build.sh
 ```
+
+## Nmap Orchestrator Config Reference (`config.toml`)
+
+Use `config.toml` as the source of truth for deterministic orchestration inputs.
+
+| Section | Required Keys | Purpose |
+|---|---|---|
+| Root | `schema_version`, `project`, `release` | Declares schema compatibility and build identity. |
+| `[orchestrator]` | `engine`, `flags`, `output_format` | Enforces Nmap engine usage and required `-Pn -sn` XML pipeline behavior. |
+| `[audit]` | `root_path`, `target`, `nse_script`, `fail_on_deviation` | Sets host-path root, local loopback target, Lua NSE logic entrypoint, and non-zero exit policy. |
+| `[timing]` | `template`, `max_template`, `scan_interval_seconds` | Captures WSL2/9P-safe timing profile (`T2` by default; `T3` only after validation). |
+| `[artifacts]` | `xml_output`, `policy_output` | Defines canonical XML output and optional expanded policy output. |
+| `[[targets]]` | `id`, `path`, `required`, `sha256`, `owner`, `group`, `mode` | Declares each audited target and expected state constraints. |
+
+Example schema template is provided at repository root: `config.toml`.
 
 ## Compliance Dashboard
 

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,63 @@
+# IĀTŌ‑V7 orchestrator configuration schema template.
+# Source of truth for deterministic Nmap-based host-path auditing.
+
+schema_version = "1.0.0"
+project = "iato-v7"
+release = "0.1.0"
+
+[orchestrator]
+# Required deterministic execution flags.
+engine = "nmap"
+flags = ["-Pn", "-sn", "-n"]
+output_format = "xml"
+
+[audit]
+# Root path mounted into the execution environment (WSL2/Minikube).
+root_path = "/mnt/host"
+# Nmap target should remain loopback for local-only orchestration.
+target = "127.0.0.1"
+# Lua NSE script implementing in-process validation logic.
+nse_script = "lean/iato_v7/nse/path_audit.nse"
+# Fail the build (non-zero exit) when any deviation is detected.
+fail_on_deviation = true
+
+[timing]
+# Use T2 by default in WSL2/9P environments for deterministic behavior.
+template = "T2"
+# Set to T3 only after validated host-path throughput.
+max_template = "T3"
+# Optional interval between scans; 0 disables polling.
+scan_interval_seconds = 0
+
+[artifacts]
+# Mandatory canonical artifact.
+xml_output = "lean/iato_v7/nmap-path-state.xml"
+# Optional machine-readable policy expansion produced by orchestrator.
+policy_output = "lean/iato_v7/.nmap-path-policy.json"
+
+[[targets]]
+id = "kubelet-config"
+path = "/etc/kubernetes/kubelet.conf"
+required = true
+sha256 = "<expected_sha256_hex>"
+owner = "root"
+group = "root"
+mode = "0644"
+
+[[targets]]
+id = "audit-rules"
+path = "/etc/audit/rules.d"
+required = true
+sha256 = "<expected_sha256_hex_or_manifest_hash>"
+owner = "root"
+group = "root"
+mode = "0750"
+
+[[targets]]
+id = "app-config"
+path = "/opt/iato/config"
+required = false
+sha256 = "<expected_sha256_hex_or_manifest_hash>"
+owner = "iato"
+group = "iato"
+mode = "0750"


### PR DESCRIPTION
### Motivation
- Replace the previous high-level summary with a deterministic, Nmap-driven orchestration model for host-path auditing. 
- Provide a canonical, machine-readable manifest so orchestration inputs and expected state are auditable and reproducible. 
- Surface the orchestration components and practical Quick Start steps for teams using WSL2/Minikube and Lean-based formal artifacts.

### Description
- Rewrite `README.md` executive summary and Quick Start to describe an Nmap-based orchestration pattern, add architecture table, and expand the Quick Start flow with a deterministic manifest initialization step. 
- Add a new `config.toml` template at repository root that defines schema metadata, `[orchestrator]`, `[audit]`, `[timing]`, `[artifacts]`, and sample `[[targets]]` entries for deterministic path auditing. 
- Document required Nmap flags and expected XML artifact outputs and show example commands for `lake test`, `scripts/scan_workers.py`, and `./scripts/lake_build.sh`. 
- Add a dedicated "Nmap Orchestrator Config Reference" section in `README.md` pointing to the new `config.toml` schema and example locations.

### Testing
- No automated tests were executed as part of this documentation and configuration-template change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a63280ca5883288c989f081e7ec214)