### PR TITLE
Deterministic audit orchestrator: canonical XML, policy snapshot and append-only MCP log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ Thumbs.db
 # Nmap orchestration artifacts
 lean/iato_v7/.nmap-path-policy.json
 lean/iato_v7/nmap-path-state.xml
+lean/iato_v7/mcp-orchestration.jsonl
 
 # Local audit configuration (may contain environment-specific/sensitive values)
 config.local.toml

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ Manifest Parser ──► Policy Builder ──► Command Planner
 
 ## Quick Start (Linux)
 
-**Run:** `iato-scan --config config.local.toml`  
-**Output:** `lean/iato_v7/nmap-path-state.xml`  
+**Run:** `iato scan --config config.local.toml`  
+**Output:** `lean/iato_v7/nmap-path-state.xml` + `lean/iato_v7/mcp-orchestration.jsonl`  
 **Exit:** `0 = Clean`, non-zero = Dirty or error
 
 ### Setup
@@ -134,7 +134,7 @@ git clone https://github.com/<whatheheckisthis>/Intent-to-Auditable-Trust-Object
 cd Intent-to-Auditable-Trust-Object
 
 # Dependencies
-sudo apt update && sudo apt install -y git curl python3 python3-pip build-essential nmap
+sudo apt update && sudo apt install -y git curl python3 python3-pip build-essential
 
 # Lean toolchain
 ./scripts/install-formal-verification-deps.sh
@@ -146,8 +146,8 @@ python3 scripts/scan_workers.py data/legacy_workers.csv
 ./scripts/lake_build.sh
 
 # Alias
-alias iato-scan='python3 lean/iato_v7/scripts/nmap_path_audit_orchestrator.py'
-echo "alias iato-scan='python3 lean/iato_v7/scripts/nmap_path_audit_orchestrator.py'" >> ~/.bashrc
+alias iato='./bin/iato'
+echo "alias iato='./bin/iato'" >> ~/.bashrc
 source ~/.bashrc
 ```
 
@@ -161,25 +161,15 @@ schema_version = "1.0.0"
 project = "iato-v7"
 release = "local"
 
-[orchestrator]
-engine = "nmap"
-flags = ["-Pn", "-sn", "-n"]
-output_format = "xml"
-
 [audit]
 root_path = "/"
 target = "127.0.0.1"
-nse_script = "lean/iato_v7/nse/path_audit.nse"
 fail_on_deviation = true
-
-[timing]
-template = "T2"
-max_template = "T3"
-scan_interval_seconds = 0
 
 [artifacts]
 xml_output = "lean/iato_v7/nmap-path-state.xml"
 policy_output = "lean/iato_v7/.nmap-path-policy.json"
+log_output = "lean/iato_v7/mcp-orchestration.jsonl"
 
 [[targets]]
 id = "jboss-service-unit"
@@ -205,8 +195,8 @@ find /path/to/dir -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum
 ### Run
 
 ```bash
-iato-scan --config config.local.toml --dry-run   # Preview command only
-iato-scan --config config.local.toml             # Produce artefact
+iato scan --config config.local.toml --dry-run   # Preview command only
+iato scan --config config.local.toml             # Produce artefacts
 echo $?                                           # 0 = Clean
 ```
 

--- a/bin/iato
+++ b/bin/iato
@@ -29,12 +29,10 @@ done
 [[ -f "lean/iato_v7/scripts/nmap_path_audit_orchestrator.py" ]] || {
   echo "Run from repo root (missing lean/iato_v7/scripts/nmap_path_audit_orchestrator.py)"; exit 1; }
 command -v python3 >/dev/null || { echo "python3 not found. Install: sudo apt install -y python3"; exit 127; }
-command -v nmap >/dev/null || { echo "nmap not found. Install: sudo apt install -y nmap"; exit 127; }
-
 echo "IĀTŌ-V7: Auditing your declared intent..."
 args=(python3 lean/iato_v7/scripts/nmap_path_audit_orchestrator.py --config "$CONFIG")
 if [[ "$DRY" -eq 1 ]]; then
-  echo "Dry-run mode: Showing deterministic Nmap command only."
+  echo "Dry-run mode: Showing deterministic orchestration context only."
   args+=(--dry-run)
 fi
 

--- a/config.toml
+++ b/config.toml
@@ -1,63 +1,31 @@
-# IĀTŌ‑V7 orchestrator configuration schema template.
-# Source of truth for deterministic Nmap-based host-path auditing.
-
 schema_version = "1.0.0"
 project = "iato-v7"
-release = "0.1.0"
-
-[orchestrator]
-# Required deterministic execution flags.
-engine = "nmap"
-flags = ["-Pn", "-sn", "-n"]
-output_format = "xml"
+release = "0.7.0"
 
 [audit]
-# Root path mounted into the execution environment (WSL2/Minikube).
-root_path = "/mnt/host"
-# Nmap target should remain loopback for local-only orchestration.
+root_path = "/workspace/Intent-to-Auditable-Trust-Object-v7"
 target = "127.0.0.1"
-# Lua NSE script implementing in-process validation logic.
-nse_script = "lean/iato_v7/nse/path_audit.nse"
-# Fail the build (non-zero exit) when any deviation is detected.
 fail_on_deviation = true
 
-[timing]
-# Use T2 by default in WSL2/9P environments for deterministic behavior.
-template = "T2"
-# Set to T3 only after validated host-path throughput.
-max_template = "T3"
-# Optional interval between scans; 0 disables polling.
-scan_interval_seconds = 0
-
 [artifacts]
-# Mandatory canonical artifact.
 xml_output = "lean/iato_v7/nmap-path-state.xml"
-# Optional machine-readable policy expansion produced by orchestrator.
 policy_output = "lean/iato_v7/.nmap-path-policy.json"
+log_output = "lean/iato_v7/mcp-orchestration.jsonl"
 
 [[targets]]
-id = "kubelet-config"
-path = "/etc/kubernetes/kubelet.conf"
+id = "lakefile"
+path = "lakefile.toml"
 required = true
-sha256 = "<expected_sha256_hex>"
-owner = "root"
-group = "root"
+sha256 = "0000000000000000000000000000000000000000000000000000000000000000"
+owner = "0"
+group = "0"
 mode = "0644"
 
 [[targets]]
-id = "audit-rules"
-path = "/etc/audit/rules.d"
+id = "orchestrator-script"
+path = "lean/iato_v7/scripts/nmap_path_audit_orchestrator.py"
 required = true
-sha256 = "<expected_sha256_hex_or_manifest_hash>"
-owner = "root"
-group = "root"
-mode = "0750"
-
-[[targets]]
-id = "app-config"
-path = "/opt/iato/config"
-required = false
-sha256 = "<expected_sha256_hex_or_manifest_hash>"
-owner = "iato"
-group = "iato"
-mode = "0750"
+sha256 = "0000000000000000000000000000000000000000000000000000000000000000"
+owner = "0"
+group = "0"
+mode = "0755"

--- a/lean/iato_v7/scripts/nmap_path_audit_orchestrator.py
+++ b/lean/iato_v7/scripts/nmap_path_audit_orchestrator.py
@@ -1,185 +1,431 @@
 #!/usr/bin/env python3
-"""Deterministic Nmap orchestrator for host-path state collection.
+"""IATO-V7 deterministic filesystem audit orchestrator.
 
-This wrapper builds an Nmap command from repository templates and runtime
-parameters, then executes `nmap -Pn -sn` with a custom NSE script to emit XML.
+Produces three delivery artefacts per run:
+1) Canonical XML audit artefact
+2) Deterministic JSON policy snapshot derived from TOML intent
+3) Append-only MCP orchestration log (JSONL)
 """
 
 from __future__ import annotations
 
 import argparse
+import datetime as dt
+import hashlib
 import json
 import os
-import re
-import shlex
-import subprocess
+import pwd
+import grp
+import stat
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+import xml.etree.ElementTree as ET
 
 try:
     import tomllib
 except ModuleNotFoundError:  # pragma: no cover - Python <3.11 fallback
     import tomli as tomllib
 
-
 REPO_ROOT = Path(__file__).resolve().parents[3]
-DEFAULT_TOML = REPO_ROOT / "lakefile.toml"
-DEFAULT_SETUP_MD = REPO_ROOT / "lean/iato_v7/ci-proxy-worker-setup.md"
-DEFAULT_K8S_YAML = REPO_ROOT / "lean/iato_v7/k8s-ci-proxy-worker.yaml"
-DEFAULT_PROXY_SCRIPT = REPO_ROOT / "lean/iato_v7/run-ci-proxy.sh"
+DEFAULT_CONFIG = REPO_ROOT / "config.toml"
+DEFAULT_XML_OUT = REPO_ROOT / "lean/iato_v7/nmap-path-state.xml"
 DEFAULT_POLICY_OUT = REPO_ROOT / "lean/iato_v7/.nmap-path-policy.json"
+DEFAULT_LOG_OUT = REPO_ROOT / "lean/iato_v7/mcp-orchestration.jsonl"
 
 
 class ConfigError(RuntimeError):
-    pass
+    """Raised when the manifest is invalid."""
 
 
-def _read(path: Path) -> str:
+@dataclass(frozen=True)
+class TargetRule:
+    rule_id: str
+    path: str
+    required: bool
+    sha256: str | None
+    owner: str | None
+    group: str | None
+    mode: str | None
+
+
+@dataclass(frozen=True)
+class Manifest:
+    schema_version: str
+    project: str
+    release: str
+    root_path: str
+    target: str
+    fail_on_deviation: bool
+    xml_output: Path
+    policy_output: Path
+    log_output: Path
+    targets: tuple[TargetRule, ...]
+
+
+def _read_toml(path: Path) -> dict[str, Any]:
     if not path.exists():
-        raise ConfigError(f"required file missing: {path}")
-    return path.read_text(encoding="utf-8")
+        raise ConfigError(f"config not found: {path}")
+    return tomllib.loads(path.read_text(encoding="utf-8"))
 
 
-def load_lake_template(path: Path) -> dict[str, Any]:
-    data = tomllib.loads(_read(path))
-    tool = data.get("tool", {})
-    iato = tool.get("iato_nmap", {})
-    if not iato:
-        raise ConfigError("[tool.iato_nmap] not found in lakefile.toml")
-    return {
-        "project_name": data.get("name", "iato-v7"),
-        "project_version": data.get("version", "unknown"),
-        "nmap": iato,
-    }
+def _require_str(container: dict[str, Any], key: str, context: str) -> str:
+    value = container.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ConfigError(f"missing/invalid string: {context}.{key}")
+    return value.strip()
 
 
-def parse_k8s_defaults(path: Path) -> dict[str, str]:
-    text = _read(path)
-    working_dir = re.search(r"workingDir:\s*(\S+)", text)
-    scaffold = re.search(
-        r"-\s+name:\s+SCAFFOLD_FILE\s+\n\s+value:\s*(\S+)", text, re.MULTILINE
+def _resolve_artifact(path_value: str, fallback: Path) -> Path:
+    candidate = Path(path_value)
+    if not str(candidate):
+        return fallback
+    return candidate if candidate.is_absolute() else (REPO_ROOT / candidate)
+
+
+def _normalize_mode(mode: str | None) -> str | None:
+    if mode is None:
+        return None
+    normalized = mode.strip()
+    if len(normalized) == 3 and normalized.isdigit():
+        normalized = f"0{normalized}"
+    if len(normalized) != 4 or not normalized.isdigit():
+        raise ConfigError(f"invalid mode '{mode}', expected 3/4 digit octal string")
+    return normalized
+
+
+def parse_manifest(path: Path) -> Manifest:
+    raw = _read_toml(path)
+
+    schema_version = _require_str(raw, "schema_version", "root")
+    project = _require_str(raw, "project", "root")
+    release = _require_str(raw, "release", "root")
+
+    audit = raw.get("audit")
+    artifacts = raw.get("artifacts")
+    targets_raw = raw.get("targets")
+
+    if not isinstance(audit, dict):
+        raise ConfigError("missing [audit] table")
+    if not isinstance(artifacts, dict):
+        raise ConfigError("missing [artifacts] table")
+    if not isinstance(targets_raw, list) or not targets_raw:
+        raise ConfigError("missing [[targets]] entries")
+
+    root_path = _require_str(audit, "root_path", "audit")
+    target = _require_str(audit, "target", "audit")
+    fail_on_deviation = bool(audit.get("fail_on_deviation", True))
+
+    xml_output = _resolve_artifact(str(artifacts.get("xml_output", DEFAULT_XML_OUT)), DEFAULT_XML_OUT)
+    policy_output = _resolve_artifact(
+        str(artifacts.get("policy_output", DEFAULT_POLICY_OUT)), DEFAULT_POLICY_OUT
     )
-    return {
-        "working_dir": working_dir.group(1) if working_dir else "/workspace",
-        "scaffold_file": scaffold.group(1) if scaffold else "/config/k8s-build-job.yaml",
+    log_output = _resolve_artifact(str(artifacts.get("log_output", DEFAULT_LOG_OUT)), DEFAULT_LOG_OUT)
+
+    parsed_targets: list[TargetRule] = []
+    for idx, raw_target in enumerate(targets_raw):
+        if not isinstance(raw_target, dict):
+            raise ConfigError(f"targets[{idx}] must be a table")
+        rule_id = _require_str(raw_target, "id", f"targets[{idx}]")
+        target_path = _require_str(raw_target, "path", f"targets[{idx}]")
+        required = bool(raw_target.get("required", True))
+        sha256 = raw_target.get("sha256")
+        owner = raw_target.get("owner")
+        group_name = raw_target.get("group")
+        mode = _normalize_mode(raw_target.get("mode"))
+
+        if sha256 is not None and (not isinstance(sha256, str) or len(sha256.strip()) != 64):
+            raise ConfigError(f"targets[{idx}].sha256 must be a 64-char hex string")
+
+        parsed_targets.append(
+            TargetRule(
+                rule_id=rule_id,
+                path=target_path,
+                required=required,
+                sha256=sha256.strip() if isinstance(sha256, str) else None,
+                owner=owner.strip() if isinstance(owner, str) else None,
+                group=group_name.strip() if isinstance(group_name, str) else None,
+                mode=mode,
+            )
+        )
+
+    return Manifest(
+        schema_version=schema_version,
+        project=project,
+        release=release,
+        root_path=root_path,
+        target=target,
+        fail_on_deviation=fail_on_deviation,
+        xml_output=xml_output,
+        policy_output=policy_output,
+        log_output=log_output,
+        targets=tuple(sorted(parsed_targets, key=lambda rule: (rule.rule_id, rule.path))),
+    )
+
+
+def compute_sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def resolve_target_path(root_path: str, configured_path: str) -> Path:
+    candidate = Path(configured_path)
+    if candidate.is_absolute():
+        return candidate
+    return Path(root_path) / candidate
+
+
+def expected_uid(owner: str | None) -> int | None:
+    if owner is None:
+        return None
+    if owner.isdigit():
+        return int(owner)
+    return pwd.getpwnam(owner).pw_uid
+
+
+def expected_gid(group_name: str | None) -> int | None:
+    if group_name is None:
+        return None
+    if group_name.isdigit():
+        return int(group_name)
+    return grp.getgrnam(group_name).gr_gid
+
+
+def evaluate_targets(manifest: Manifest) -> tuple[list[dict[str, Any]], int]:
+    evaluated: list[dict[str, Any]] = []
+    deviation_count = 0
+
+    for rule in manifest.targets:
+        target_path = resolve_target_path(manifest.root_path, rule.path)
+        deviations: list[str] = []
+        observed: dict[str, Any] = {
+            "exists": target_path.exists(),
+            "sha256": None,
+            "uid": None,
+            "gid": None,
+            "mode": None,
+            "size": None,
+        }
+
+        if observed["exists"]:
+            st = target_path.stat()
+            observed["uid"] = st.st_uid
+            observed["gid"] = st.st_gid
+            observed["mode"] = format(stat.S_IMODE(st.st_mode), "04o")
+            observed["size"] = st.st_size
+            if target_path.is_file():
+                observed["sha256"] = compute_sha256(target_path)
+
+        if rule.required and not observed["exists"]:
+            deviations.append("missing_required_path")
+        if rule.sha256 and observed["exists"] and observed["sha256"] != rule.sha256:
+            deviations.append("sha256_mismatch")
+        if rule.mode and observed["exists"] and observed["mode"] != rule.mode:
+            deviations.append("mode_mismatch")
+        if rule.owner is not None and observed["exists"]:
+            if observed["uid"] != expected_uid(rule.owner):
+                deviations.append("owner_mismatch")
+        if rule.group is not None and observed["exists"]:
+            if observed["gid"] != expected_gid(rule.group):
+                deviations.append("group_mismatch")
+
+        deviation_count += len(deviations)
+        evaluated.append(
+            {
+                "id": rule.rule_id,
+                "path": str(target_path),
+                "configured_path": rule.path,
+                "required": rule.required,
+                "expected": {
+                    "sha256": rule.sha256,
+                    "owner": rule.owner,
+                    "group": rule.group,
+                    "mode": rule.mode,
+                },
+                "observed": observed,
+                "deviations": deviations,
+                "status": "Clean" if not deviations else "Dirty",
+            }
+        )
+
+    return evaluated, deviation_count
+
+
+def write_policy_snapshot(manifest: Manifest) -> None:
+    payload = {
+        "schema_version": manifest.schema_version,
+        "project": manifest.project,
+        "release": manifest.release,
+        "root_path": manifest.root_path,
+        "target": manifest.target,
+        "rules": [
+            {
+                "id": t.rule_id,
+                "path": t.path,
+                "required": t.required,
+                "sha256": t.sha256,
+                "owner": t.owner,
+                "group": t.group,
+                "mode": t.mode,
+            }
+            for t in manifest.targets
+        ],
     }
+    manifest.policy_output.parent.mkdir(parents=True, exist_ok=True)
+    manifest.policy_output.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
 
 
-def parse_proxy_defaults(path: Path) -> dict[str, str]:
-    text = _read(path)
-    workdir = re.search(r'WORKDIR="\$\{WORKDIR:-([^}]+)\}"', text)
-    scaffold = re.search(r'SCAFFOLD_FILE="\$\{SCAFFOLD_FILE:-([^}]+)\}"', text)
-    return {
-        "workdir": workdir.group(1) if workdir else "/workspace",
-        "scaffold_file": scaffold.group(1) if scaffold else "/config/k8s-build-job.yaml",
+def write_canonical_xml(manifest: Manifest, evaluated: list[dict[str, Any]], deviation_count: int) -> None:
+    status = "Clean" if deviation_count == 0 else "Dirty"
+    generated_at = dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
+
+    root = ET.Element(
+        "iato_path_audit",
+        {
+            "schema_version": manifest.schema_version,
+            "project": manifest.project,
+            "release": manifest.release,
+            "generated_at": generated_at,
+        },
+    )
+    ET.SubElement(
+        root,
+        "summary",
+        {
+            "status": status,
+            "evaluated_targets": str(len(evaluated)),
+            "deviation_count": str(deviation_count),
+        },
+    )
+
+    targets_el = ET.SubElement(root, "targets")
+    for item in sorted(evaluated, key=lambda row: (row["id"], row["configured_path"])):
+        t_el = ET.SubElement(
+            targets_el,
+            "target",
+            {
+                "id": item["id"],
+                "path": item["path"],
+                "configured_path": item["configured_path"],
+                "required": str(item["required"]).lower(),
+                "status": item["status"],
+            },
+        )
+        ET.SubElement(
+            t_el,
+            "expected",
+            {k: "" if v is None else str(v) for k, v in item["expected"].items()},
+        )
+        ET.SubElement(
+            t_el,
+            "observed",
+            {k: "" if v is None else str(v) for k, v in item["observed"].items()},
+        )
+        deviations_el = ET.SubElement(t_el, "deviations")
+        for code in item["deviations"]:
+            ET.SubElement(deviations_el, "deviation", {"code": code})
+
+    ET.indent(root, space="  ")
+    xml_text = ET.tostring(root, encoding="unicode")
+
+    manifest.xml_output.parent.mkdir(parents=True, exist_ok=True)
+    manifest.xml_output.write_text('<?xml version="1.0" encoding="UTF-8"?>\n' + xml_text + "\n", encoding="utf-8")
+
+
+def validate_xml_schema(xml_path: Path) -> None:
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+    if root.tag != "iato_path_audit":
+        raise ConfigError("xml schema validation failed: root element must be iato_path_audit")
+
+    required_root_attrs = ["schema_version", "project", "release", "generated_at"]
+    for attr in required_root_attrs:
+        if attr not in root.attrib or not root.attrib[attr]:
+            raise ConfigError(f"xml schema validation failed: missing root attribute '{attr}'")
+
+    summary = root.find("summary")
+    if summary is None:
+        raise ConfigError("xml schema validation failed: missing summary node")
+
+    if summary.get("status") not in {"Clean", "Dirty"}:
+        raise ConfigError("xml schema validation failed: summary status must be Clean or Dirty")
+
+
+def append_mcp_log(
+    manifest: Manifest,
+    command_chain: list[str],
+    exit_state: str,
+    deviation_flag: bool,
+) -> None:
+    script_hash = hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+    payload = {
+        "timestamp": dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat(),
+        "script_version_hash": script_hash,
+        "command_chain": command_chain,
+        "exit_state": exit_state,
+        "deviation_flag": deviation_flag,
     }
-
-
-def parse_setup_notes(path: Path) -> dict[str, str]:
-    text = _read(path)
-    mount_match = re.search(r"minikube mount[^\n]+", text)
-    return {"mount_hint": mount_match.group(0) if mount_match else "minikube mount <src>:<dst>"}
-
-
-def check_nmap_version(expected: str) -> None:
-    proc = subprocess.run(["nmap", "--version"], capture_output=True, text=True, check=False)
-    if proc.returncode != 0:
-        raise ConfigError("nmap is required but not available in PATH")
-    first_line = proc.stdout.splitlines()[0] if proc.stdout else ""
-    found = re.search(r"([0-9]+\.[0-9]+)", first_line)
-    if not found:
-        raise ConfigError(f"unable to parse nmap version from: {first_line!r}")
-    if found.group(1) != expected:
-        raise ConfigError(f"determinism gate failed: expected nmap {expected}, found {found.group(1)}")
-
-
-def validate_headless(nmap_cfg: dict[str, Any]) -> None:
-    if nmap_cfg.get("headless", True) is not True:
-        raise ConfigError("determinism gate failed: [tool.iato_nmap].headless must be true")
-
-
-def build_policy(rules: list[dict[str, Any]], root_path: str) -> dict[str, Any]:
-    ordered = sorted(rules, key=lambda item: item["path"])
-    return {
-        "root_path": root_path,
-        "rules": ordered,
-    }
-
-
-def build_command(cfg: dict[str, Any], policy_path: Path, xml_out: Path) -> list[str]:
-    nmap_cfg = cfg["nmap"]
-    script_path = nmap_cfg["nse_script"]
-    target = nmap_cfg.get("target", "127.0.0.1")
-    script_args = {
-        "path_audit.root": nmap_cfg["root_path"],
-        "path_audit.policy": str(policy_path),
-        "path_audit.schema": nmap_cfg.get("schema_version", "1.0.0"),
-        "path_audit.project": cfg["project_name"],
-        "path_audit.release": cfg["project_version"],
-    }
-    args_value = ",".join(f"{k}={script_args[k]}" for k in sorted(script_args.keys()))
-    return [
-        "nmap",
-        "--noninteractive",
-        "-Pn",
-        "-sn",
-        "-n",
-        "--script",
-        script_path,
-        "--script-args",
-        args_value,
-        "-oX",
-        str(xml_out),
-        target,
-    ]
+    manifest.log_output.parent.mkdir(parents=True, exist_ok=True)
+    with manifest.log_output.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True) + "\n")
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Build and run deterministic Nmap path-audit command")
-    parser.add_argument("--config", type=Path, default=DEFAULT_TOML)
-    parser.add_argument("--setup-md", type=Path, default=DEFAULT_SETUP_MD)
-    parser.add_argument("--k8s-yaml", type=Path, default=DEFAULT_K8S_YAML)
-    parser.add_argument("--proxy-script", type=Path, default=DEFAULT_PROXY_SCRIPT)
-    parser.add_argument("--policy-out", type=Path, default=DEFAULT_POLICY_OUT)
-    parser.add_argument("--xml-out", type=Path, default=REPO_ROOT / "lean/iato_v7/nmap-path-state.xml")
+    parser = argparse.ArgumentParser(description="IATO-V7 deterministic path audit")
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
     parser.add_argument("--dry-run", action="store_true")
-    parser.add_argument("--skip-version-check", action="store_true")
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
-    cfg = load_lake_template(args.config)
-    notes = parse_setup_notes(args.setup_md)
-    k8s_defaults = parse_k8s_defaults(args.k8s_yaml)
-    proxy_defaults = parse_proxy_defaults(args.proxy_script)
+    command_chain = [
+        "load_manifest",
+        "write_policy_snapshot",
+        "evaluate_targets",
+        "write_canonical_xml",
+        "validate_xml_schema",
+    ]
 
-    nmap_cfg = cfg["nmap"]
-    validate_headless(nmap_cfg)
-    if not args.skip_version_check:
-        check_nmap_version(nmap_cfg["nmap_version"])
+    try:
+        manifest = parse_manifest(args.config)
 
-    policy = build_policy(nmap_cfg.get("path_rules", []), nmap_cfg["root_path"])
-    args.policy_out.parent.mkdir(parents=True, exist_ok=True)
-    args.policy_out.write_text(json.dumps(policy, indent=2, sort_keys=True), encoding="utf-8")
+        print("[iato-v7] deterministic orchestration context:")
+        print(f"  config={args.config}")
+        print(f"  xml_output={manifest.xml_output}")
+        print(f"  policy_output={manifest.policy_output}")
+        print(f"  log_output={manifest.log_output}")
+        print(f"  declared_targets={len(manifest.targets)}")
 
-    cmd = build_command(cfg, args.policy_out, args.xml_out)
-    print("[iato-v7] deterministic orchestration context:")
-    print(f"  mount_hint={notes['mount_hint']}")
-    print(f"  k8s_working_dir={k8s_defaults['working_dir']}")
-    print(f"  proxy_workdir={proxy_defaults['workdir']}")
-    print(f"  policy_file={args.policy_out}")
-    print(f"  xml_output={args.xml_out}")
-    print(f"  command={shlex.join(cmd)}")
+        if args.dry_run:
+            append_mcp_log(manifest, command_chain, "dry_run", False)
+            return 0
 
-    if args.dry_run:
+        write_policy_snapshot(manifest)
+        evaluated, deviation_count = evaluate_targets(manifest)
+        write_canonical_xml(manifest, evaluated, deviation_count)
+        validate_xml_schema(manifest.xml_output)
+
+        dirty = deviation_count > 0
+        if dirty and manifest.fail_on_deviation:
+            append_mcp_log(manifest, command_chain, "dirty", True)
+            return 3
+
+        append_mcp_log(manifest, command_chain, "clean", False)
         return 0
-
-    env = os.environ.copy()
-    env["IATO_V7_STATELESS"] = "1"
-    proc = subprocess.run(cmd, env=env, check=False)
-    return proc.returncode
+    except Exception as exc:  # pragma: no cover - runtime guard
+        print(f"[iato-v7] orchestration failure: {exc}", file=sys.stderr)
+        # best effort log write when config parses cleanly
+        try:
+            manifest = parse_manifest(args.config)
+            append_mcp_log(manifest, command_chain, "error", True)
+        except Exception:
+            pass
+        return 2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Provide a deterministic, declared-intent orchestration flow that converts a TOML manifest into machine-verifiable artefacts for audit evidence.
- Ensure observed filesystem state is compared to declared intent with deterministic ordering, stable artifact paths, and strict schema/exit semantics.
- Emit an append-only operational log suitable for forensic reconstruction of every run and to keep machine-local evidence out of VCS.

### Description
- Rewrote the orchestrator at `lean/iato_v7/scripts/nmap_path_audit_orchestrator.py` to parse a declared-intent TOML manifest (`schema_version`, `[audit]`, `[artifacts]`, `[[targets]]`), validate fields, deterministically sort targets, evaluate existence/sha256/uid/gid/mode, write a deterministic policy snapshot, and emit canonical XML at `lean/iato_v7/nmap-path-state.xml` with schema checks and Clean/Dirty semantics.
- Added append-only MCP orchestration logging to `lean/iato_v7/mcp-orchestration.jsonl` capturing `timestamp`, `script_version_hash`, `command_chain`, `exit_state`, and `deviation_flag` and updated `.gitignore` to ignore this local artefact.
- Updated the CLI wrapper `bin/iato` to call the local orchestrator (`iato scan`), remove the hard `nmap` runtime gate in the wrapper, and clarify dry-run messaging to reflect orchestration context preview.
- Updated `config.toml` and `README.md` to the declared-intent schema, document both produced artefacts (`nmap-path-state.xml` and `mcp-orchestration.jsonl`), and align quick-start examples with the new flow.

### Testing
- `python3 -m py_compile lean/iato_v7/scripts/nmap_path_audit_orchestrator.py` succeeded, confirming Python syntax correctness.
- `./bin/iato scan --dry-run` succeeded and printed the deterministic orchestration context, validating CLI integration and dry-run behavior.
- `python3 lean/iato_v7/scripts/nmap_path_audit_orchestrator.py --config config.toml` executed and returned `RC:3` with placeholder SHA256 values, demonstrating expected non-zero (Dirty) exit semantics; generated `lean/iato_v7/nmap-path-state.xml` and appended entries to `lean/iato_v7/mcp-orchestration.jsonl` as observed during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c24ed3c6048323ac36335764937ef6)